### PR TITLE
Added video grid cards example with PIP-enabled functionalty

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -62,11 +62,15 @@
             android:exported="true"
             android:theme="@style/Theme.Example.LeanbackVerticalGrid"></activity>
         <activity
+            android:name=".app.grid.VideoGridExampleActivity"
+            android:exported="true"
+            android:theme="@style/Theme.Example.LeanbackVerticalGrid"></activity>
+        <activity
             android:name=".app.media.VideoExampleActivity"
             android:exported="true"
             android:theme="@style/Theme.Example.Leanback"
             android:configChanges="screenSize|smallestScreenSize|screenLayout|orientation|layoutDirection"
-            android:launchMode="singleTask"
+            android:launchMode="standard"
             android:resizeableActivity="true"
             android:supportsPictureInPicture="true"
             ></activity>

--- a/app/src/main/java/android/support/v17/leanback/supportleanbackshowcase/app/MainFragment.java
+++ b/app/src/main/java/android/support/v17/leanback/supportleanbackshowcase/app/MainFragment.java
@@ -22,6 +22,7 @@ import android.support.v17.leanback.supportleanbackshowcase.app.cards.CardExampl
 import android.support.v17.leanback.supportleanbackshowcase.app.details.DetailViewExampleActivity;
 import android.support.v17.leanback.supportleanbackshowcase.app.dialog.DialogExampleActivity;
 import android.support.v17.leanback.supportleanbackshowcase.app.grid.GridExampleActivity;
+import android.support.v17.leanback.supportleanbackshowcase.app.grid.VideoGridExampleActivity;
 import android.support.v17.leanback.supportleanbackshowcase.app.media.MusicExampleActivity;
 import android.support.v17.leanback.supportleanbackshowcase.app.media.VideoExampleActivity;
 import android.support.v17.leanback.supportleanbackshowcase.app.page.PageAndListRowActivity;
@@ -122,20 +123,25 @@ public class MainFragment extends BrowseFragment {
                 }
                 case 3: {
                     intent = new Intent(getActivity().getBaseContext(),
-                            DetailViewExampleActivity.class);
+                            VideoGridExampleActivity.class);
                     break;
                 }
                 case 4: {
                     intent = new Intent(getActivity().getBaseContext(),
-                            VideoExampleActivity.class);
+                            DetailViewExampleActivity.class);
                     break;
                 }
                 case 5: {
                     intent = new Intent(getActivity().getBaseContext(),
-                            MusicExampleActivity.class);
+                            VideoExampleActivity.class);
                     break;
                 }
                 case 6: {
+                    intent = new Intent(getActivity().getBaseContext(),
+                            MusicExampleActivity.class);
+                    break;
+                }
+                case 7: {
                     // Let's create a new Wizard for a given Movie. The movie can come from any sort
                     // of data source. To simplify this example we decode it from a JSON source
                     // which might be loaded from a server in a real world example.
@@ -154,13 +160,13 @@ public class MainFragment extends BrowseFragment {
                     // Finally, start the wizard Activity.
                     break;
                 }
-                case 7: {
+                case 8: {
                     intent = new Intent(getActivity().getBaseContext(),
                             SettingsExampleActivity.class);
                     startActivity(intent);
                     return;
                 }
-                case 8: {
+                case 9: {
                     intent = new Intent(getActivity().getBaseContext(),
                             DialogExampleActivity.class);
                     break;

--- a/app/src/main/java/android/support/v17/leanback/supportleanbackshowcase/app/grid/VideoGridExampleActivity.java
+++ b/app/src/main/java/android/support/v17/leanback/supportleanbackshowcase/app/grid/VideoGridExampleActivity.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2016 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package android.support.v17.leanback.supportleanbackshowcase.app.grid;
+
+import android.app.Activity;
+import android.os.Bundle;
+import android.support.v17.leanback.supportleanbackshowcase.R;
+
+/**
+ * TODO: Javadoc
+ */
+public class VideoGridExampleActivity extends Activity {
+
+    @Override public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_video_grid_example);
+    }
+}

--- a/app/src/main/java/android/support/v17/leanback/supportleanbackshowcase/app/grid/VideoGridExampleFragment.java
+++ b/app/src/main/java/android/support/v17/leanback/supportleanbackshowcase/app/grid/VideoGridExampleFragment.java
@@ -1,0 +1,238 @@
+/*
+ * Copyright (C) 2016 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package android.support.v17.leanback.supportleanbackshowcase.app.grid;
+
+import android.content.Intent;
+import android.os.AsyncTask;
+import android.os.Bundle;
+import android.os.Handler;
+import android.support.v17.leanback.app.VerticalGridFragment;
+import android.support.v17.leanback.supportleanbackshowcase.R;
+import android.support.v17.leanback.supportleanbackshowcase.app.media.MediaMetaData;
+import android.support.v17.leanback.supportleanbackshowcase.app.media.VideoExampleActivity;
+import android.support.v17.leanback.supportleanbackshowcase.cards.presenters.VideoCardViewPresenter;
+import android.support.v17.leanback.supportleanbackshowcase.models.VideoCard;
+import android.support.v17.leanback.supportleanbackshowcase.models.VideoRow;
+import android.support.v17.leanback.supportleanbackshowcase.cards.presenters.CardPresenterSelector;
+import android.support.v17.leanback.widget.ArrayObjectAdapter;
+import android.support.v17.leanback.widget.FocusHighlight;
+import android.support.v17.leanback.widget.OnItemViewClickedListener;
+import android.support.v17.leanback.widget.OnItemViewSelectedListener;
+import android.support.v17.leanback.widget.Presenter;
+import android.support.v17.leanback.widget.PresenterSelector;
+import android.support.v17.leanback.widget.Row;
+import android.support.v17.leanback.widget.RowPresenter;
+import android.support.v17.leanback.widget.VerticalGridPresenter;
+import android.util.Log;
+import android.widget.Toast;
+
+import com.google.gson.Gson;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Example fragment displaying videos in a vertical grid using {@link VerticalGridFragment}.
+ * It fetches the videos from the the url in {@link R.string.videos_url} and displays the metadata
+ * fetched from each video in an ImageCardView (using {@link VideoCardViewPresenter}).
+ * On clicking on each one of these video cards, a fresh instance of the
+ * VideoExampleActivity starts which plays the video item.
+ */
+public class VideoGridExampleFragment extends VerticalGridFragment implements
+        OnItemViewSelectedListener, OnItemViewClickedListener {
+
+    private static final int COLUMNS = 4;
+    private static final int ZOOM_FACTOR = FocusHighlight.ZOOM_FACTOR_MEDIUM;
+    private static final String TAG = "VideoGridExampleFragment";
+    private static final String TAG_CATEGORY = "googlevideos";
+    // Hashmap mapping category names to the list of videos in that category. This is fetched from
+    // the url
+    private Map<String, List<VideoCard>> categoryVideosMap = new HashMap<>();
+
+    private ArrayObjectAdapter mAdapter;
+
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setTitle(getString(R.string.video_grid_example_title));
+        setupRowAdapter();
+    }
+    private void setupRowAdapter() {
+        VerticalGridPresenter videoGridPresenter = new VerticalGridPresenter(ZOOM_FACTOR);
+        videoGridPresenter.setNumberOfColumns(COLUMNS);
+        // note: The click listeners must be called before setGridPresenter for the event listeners
+        // to be properly registered on the viewholders.
+        setOnItemViewSelectedListener(this);
+        setOnItemViewClickedListener(this);
+        setGridPresenter(videoGridPresenter);
+
+        PresenterSelector cardPresenterSelector = new CardPresenterSelector(getActivity());
+        // VideoCardViewPresenter videoCardViewPresenter = new VideoCardViewPresenter(getActivity());
+        mAdapter = new ArrayObjectAdapter(cardPresenterSelector);
+        setAdapter(mAdapter);
+
+        prepareEntranceTransition();
+        new Handler().postDelayed(new Runnable() {
+            @Override
+            public void run() {
+                createRows();
+            }
+        }, 1000);
+    }
+
+    private void createRows() {
+        String urlToFetch = getResources().getString(R.string.videos_url);
+        fetchVideosInfo(urlToFetch);;
+    }
+
+    /**
+     * Called when videos metadata are fetched from the url. The result of this fetch is returned
+     * in the form of a JSON object.
+     * @param jsonObj The json object containing the information about all the videos.
+     */
+    private void onFetchVideosInfoSuccess(JSONObject jsonObj) {
+        try {
+            String videoRowsJson = jsonObj.getString(TAG_CATEGORY);
+            VideoRow[] videoRows = new Gson().fromJson(videoRowsJson, VideoRow[].class);
+            for(VideoRow videoRow : videoRows) {
+                if (!categoryVideosMap.containsKey(videoRow.getCategory())) {
+                    categoryVideosMap.put(videoRow.getCategory(), new ArrayList<VideoCard>());
+                }
+                categoryVideosMap.get(videoRow.getCategory()).addAll(videoRow.getVideos());
+                mAdapter.addAll(mAdapter.size(), videoRow.getVideos());
+                startEntranceTransition();
+            }
+        } catch (JSONException ex) {
+            Log.e(TAG, "A JSON error occurred while fetching videos: " + ex.toString());
+        }
+    }
+
+    /**
+     * Called when an exception occurred while fetching videos meta data from the url.
+     * @param ex The exception occurred in the asynchronous task fetching videos.
+     */
+    private void onFetchVideosInfoError(Exception ex) {
+        Log.e(TAG, "Error fetching videos from " + getResources().getString(R.string.videos_url) +
+                ", Exception: " + ex.toString());
+        Toast.makeText(getContext(), "Error fetching videos from json file",
+                Toast.LENGTH_LONG).show();
+    }
+
+    /**
+     * The result type of the background computation of the url fetcher
+     */
+    private static class FetchResult {
+        private boolean isSuccess;
+        private Exception exception;
+        JSONObject jsonObj;
+
+        FetchResult(JSONObject obj) {
+            jsonObj = obj;
+            isSuccess = true;
+            exception = null;
+        }
+
+        FetchResult(Exception ex) {
+            jsonObj = null;
+            isSuccess = false;
+            exception = ex;
+        }
+    }
+
+    /**
+     * Fetches videos metadata from urlString on a background thread. Callback methods are invoked
+     * upon success or failure of this fetching.
+     * @param urlString The json file url to fetch from
+     */
+    private void fetchVideosInfo(final String urlString) {
+
+        new AsyncTask<Void, Void, FetchResult>() {
+            @Override
+            protected void onPostExecute(FetchResult fetchResult) {
+                if (fetchResult.isSuccess) {
+                    onFetchVideosInfoSuccess(fetchResult.jsonObj);
+                } else {
+                    onFetchVideosInfoError(fetchResult.exception);
+                }
+            }
+
+            @Override
+            protected FetchResult doInBackground(Void... params) {
+                BufferedReader reader = null;
+                HttpURLConnection urlConnection = null;
+                try {
+                    URL url = new URL(urlString);
+                    urlConnection =(HttpURLConnection) url.openConnection();
+                    reader = new BufferedReader(new InputStreamReader(urlConnection.getInputStream(),
+                            "utf-8"));
+                    StringBuilder sb = new StringBuilder();
+                    String line;
+                    while ( (line = reader.readLine()) != null ) {
+                        sb.append(line);
+                    }
+                    return new FetchResult(new JSONObject(sb.toString()));
+                } catch (JSONException ex) {
+                    Log.e(TAG, "A JSON error occurred while fetching videos: " + ex.toString());
+                    return new FetchResult(ex);
+                } catch (IOException ex) {
+                    Log.e(TAG, "An I/O error occurred while fetching videos: " + ex.toString());
+                    return new FetchResult(ex);
+                } finally {
+                    if (urlConnection != null) {
+                        urlConnection.disconnect();
+                    }
+                    if (reader != null) {
+                        try {
+                            reader.close();
+                        } catch (IOException ex) {
+                            Log.e(TAG, "JSON reader could not be closed! " + ex);
+                        }
+                    }
+                }
+            }
+        }.execute();
+    }
+
+    @Override
+    public void onItemClicked(Presenter.ViewHolder itemViewHolder, Object item,
+                              RowPresenter.ViewHolder rowViewHolder, Row row) {
+        Log.d(TAG, "onItem Clicked in " + this);
+        if (item instanceof  VideoCard) {
+            VideoCard itemCard = (VideoCard) item;
+            MediaMetaData metaData = new MediaMetaData();
+            metaData.setMediaSourcePath(itemCard.getVideoSource());
+            metaData.setMediaTitle(itemCard.getTitle());
+            metaData.setMediaArtistName(itemCard.getDescription());
+            Intent intent = new Intent(getActivity(), VideoExampleActivity.class);
+            intent.putExtra(VideoExampleActivity.TAG, metaData);
+            getActivity().startActivity(intent);
+        }
+    }
+
+    @Override
+    public void onItemSelected(Presenter.ViewHolder itemViewHolder, Object item,
+                               RowPresenter.ViewHolder rowViewHolder, Row row) {
+
+    }
+}

--- a/app/src/main/java/android/support/v17/leanback/supportleanbackshowcase/app/media/MediaMetaData.java
+++ b/app/src/main/java/android/support/v17/leanback/supportleanbackshowcase/app/media/MediaMetaData.java
@@ -42,7 +42,7 @@ public class MediaMetaData implements Parcelable{
         mMediaAlbumArtResId = mediaAlbumArtResId;
     }
 
-    MediaMetaData() {
+    public MediaMetaData() {
     }
 
     public MediaMetaData(Parcel in) {

--- a/app/src/main/java/android/support/v17/leanback/supportleanbackshowcase/app/media/VideoConsumptionExampleFragment.java
+++ b/app/src/main/java/android/support/v17/leanback/supportleanbackshowcase/app/media/VideoConsumptionExampleFragment.java
@@ -25,6 +25,7 @@ import android.support.v17.leanback.widget.PlaybackControlsRowPresenter;
 import android.support.v17.leanback.widget.Presenter;
 import android.support.v17.leanback.widget.Row;
 import android.support.v17.leanback.widget.RowPresenter;
+import android.util.Log;
 import android.view.SurfaceHolder;
 import android.view.SurfaceView;
 
@@ -49,12 +50,7 @@ public class VideoConsumptionExampleFragment extends PlaybackOverlayFragment imp
                 mRowsAdapter.notifyArrayItemRangeChanged(0, 1);
             }
         };
-        mGlue.setOnMediaFileFinishedPlayingListener(this);
-        MediaMetaData mediaMetaData = new MediaMetaData();
-        mediaMetaData.setMediaTitle("Diving with Sharks");
-        mediaMetaData.setMediaArtistName("A Googler");
-        mediaMetaData.setMediaSourcePath(URL);
-        mGlue.prepareIfNeededAndPlay(mediaMetaData);
+
 
 
         Fragment videoSurfaceFragment = getFragmentManager()
@@ -85,6 +81,26 @@ public class VideoConsumptionExampleFragment extends PlaybackOverlayFragment imp
     public void onStart() {
         super.onStart();
         mGlue.enableProgressUpdating(mGlue.hasValidMedia() && mGlue.isMediaPlaying());
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+       // String intentVideoUrl = getActivity().getIntent().getStringExtra(VideoExampleActivity.TAG);
+        MediaMetaData intentMetaData = getActivity().getIntent().getParcelableExtra(
+                VideoExampleActivity.TAG);
+        MediaMetaData currentMetaData = new MediaMetaData();
+        if (intentMetaData != null) {
+            currentMetaData.setMediaTitle(intentMetaData.getMediaTitle());
+            currentMetaData.setMediaArtistName(intentMetaData.getMediaArtistName());
+            currentMetaData.setMediaSourcePath(intentMetaData.getMediaSourcePath());
+        } else {
+            currentMetaData.setMediaTitle("Diving with Sharks");
+            currentMetaData.setMediaArtistName("A Googler");
+            currentMetaData.setMediaSourcePath(URL);
+        }
+        mGlue.setOnMediaFileFinishedPlayingListener(this);
+        mGlue.prepareIfNeededAndPlay(currentMetaData);
     }
 
     @Override

--- a/app/src/main/java/android/support/v17/leanback/supportleanbackshowcase/app/media/VideoExampleActivity.java
+++ b/app/src/main/java/android/support/v17/leanback/supportleanbackshowcase/app/media/VideoExampleActivity.java
@@ -17,6 +17,7 @@ package android.support.v17.leanback.supportleanbackshowcase.app.media;
 import android.app.Activity;
 import android.app.FragmentTransaction;
 import android.content.Context;
+import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.os.Bundle;
 import android.support.v17.leanback.supportleanbackshowcase.R;
@@ -41,6 +42,17 @@ public class VideoExampleActivity extends Activity {
         FragmentTransaction ft2 = getFragmentManager().beginTransaction();
         ft2.add(R.id.videoFragment, new VideoConsumptionExampleFragment(), VideoConsumptionExampleFragment.TAG);
         ft2.commit();
+    }
+
+    @Override
+    protected void onNewIntent(Intent intent) {
+        super.onNewIntent(intent);
+        // This part is necessary to ensure that getIntent returns the latest intent when
+        // VideoExampleActivity is started. By default, getIntent() returns the initial intent
+        // that was set from another activity that started VideoExampleActivity. However, we need
+        // to update this intent when for example, user clicks on another video when the currently
+        // playing video is in PIP mode, and a new video needs to be started.
+        setIntent(intent);
     }
 
     public static boolean supportsPictureInPicture(Context context) {

--- a/app/src/main/java/android/support/v17/leanback/supportleanbackshowcase/cards/presenters/CardPresenterSelector.java
+++ b/app/src/main/java/android/support/v17/leanback/supportleanbackshowcase/cards/presenters/CardPresenterSelector.java
@@ -47,6 +47,9 @@ public class CardPresenterSelector extends PresenterSelector {
                 case SINGLE_LINE:
                     presenter = new SingleLineCardPresenter(mContext);
                     break;
+                case VIDEO_GRID:
+                    presenter = new VideoCardViewPresenter(mContext, R.style.VideoGridCardTheme);
+                    break;
                 case MOVIE:
                 case MOVIE_BASE:
                 case MOVIE_COMPLETE:

--- a/app/src/main/java/android/support/v17/leanback/supportleanbackshowcase/cards/presenters/ImageCardViewPresenter.java
+++ b/app/src/main/java/android/support/v17/leanback/supportleanbackshowcase/cards/presenters/ImageCardViewPresenter.java
@@ -43,12 +43,12 @@ public class ImageCardViewPresenter extends AbstractCardPresenter<ImageCardView>
     @Override
     protected ImageCardView onCreateView() {
         ImageCardView imageCardView = new ImageCardView(getContext());
-        imageCardView.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                Toast.makeText(getContext(), "Clicked on ImageCardView", Toast.LENGTH_SHORT).show();
-            }
-        });
+//        imageCardView.setOnClickListener(new View.OnClickListener() {
+//            @Override
+//            public void onClick(View v) {
+//                Toast.makeText(getContext(), "Clicked on ImageCardView", Toast.LENGTH_SHORT).show();
+//            }
+//        });
         return imageCardView;
     }
 

--- a/app/src/main/java/android/support/v17/leanback/supportleanbackshowcase/cards/presenters/VideoCardViewPresenter.java
+++ b/app/src/main/java/android/support/v17/leanback/supportleanbackshowcase/cards/presenters/VideoCardViewPresenter.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2016 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package android.support.v17.leanback.supportleanbackshowcase.cards.presenters;
+
+import android.content.Context;
+import android.support.v17.leanback.supportleanbackshowcase.R;
+import android.support.v17.leanback.supportleanbackshowcase.models.Card;
+import android.support.v17.leanback.supportleanbackshowcase.models.VideoCard;
+import android.support.v17.leanback.widget.ImageCardView;
+import android.view.ContextThemeWrapper;
+import android.view.View;
+import android.widget.Toast;
+import com.bumptech.glide.Glide;
+
+/**
+ * Presenter for rendering video cards on the Vertical Grid fragment.
+ */
+public class VideoCardViewPresenter extends ImageCardViewPresenter {
+
+    public VideoCardViewPresenter(Context context, int cardThemeResId) {
+        super(context, cardThemeResId);
+    }
+
+    public VideoCardViewPresenter(Context context) {
+        super(context);
+    }
+
+    @Override
+    public void onBindViewHolder(Card card, final ImageCardView cardView) {
+        super.onBindViewHolder(card, cardView);
+        VideoCard videoCard = (VideoCard) card;
+        Glide.with(getContext())
+                .load(videoCard.getImageUrl())
+                .asBitmap()
+                .into(cardView.getMainImageView());
+
+    }
+
+}

--- a/app/src/main/java/android/support/v17/leanback/supportleanbackshowcase/models/Card.java
+++ b/app/src/main/java/android/support/v17/leanback/supportleanbackshowcase/models/Card.java
@@ -32,7 +32,7 @@ public class Card {
     @SerializedName("title") private String mTitle = "";
     @SerializedName("description") private String mDescription = "";
     @SerializedName("extraText") private String mExtraText = "";
-    @SerializedName("imageUrl") private String mImageUrl;
+    @SerializedName("card") private String mImageUrl;
     @SerializedName("footerColor") private String mFooterColor = null;
     @SerializedName("selectedColor") private String mSelectedColor = null;
     @SerializedName("localImageResource") private String mLocalImageResource = null;
@@ -44,6 +44,42 @@ public class Card {
 
     public String getTitle() {
         return mTitle;
+    }
+
+    public void setTitle(String title) {
+        mTitle = title;
+    }
+
+    public String getLocalImageResource() {
+        return mLocalImageResource;
+    }
+
+    public void setLocalImageResource(String localImageResource) {
+        mLocalImageResource = localImageResource;
+    }
+
+    public String getFooterResource() {
+        return mFooterResource;
+    }
+
+    public void setFooterResource(String footerResource) {
+        mFooterResource = footerResource;
+    }
+
+    public void setType(Type type) {
+        mType = type;
+    }
+
+    public void setId(int id) {
+        mId = id;
+    }
+
+    public void setWidth(int width) {
+        mWidth = width;
+    }
+
+    public void setHeight(int height) {
+        mHeight = height;
     }
 
     public int getWidth() {
@@ -66,13 +102,26 @@ public class Card {
         return mDescription;
     }
 
+    public void setDescription(String description) {
+        mDescription = description;
+    }
+
+
     public String getExtraText() {
         return mExtraText;
+    }
+
+    public void setExtraText(String extraText) {
+        mExtraText = extraText;
     }
 
     public int getFooterColor() {
         if (mFooterColor == null) return -1;
         return Color.parseColor(mFooterColor);
+    }
+
+    public void setFooterColor(String footerColor) {
+        mFooterColor = footerColor;
     }
 
     public int getSelectedColor() {
@@ -82,6 +131,14 @@ public class Card {
 
     public String getImageUrl() {
         return mImageUrl;
+    }
+
+    public void setSelectedColor(String selectedColor) {
+        mSelectedColor = selectedColor;
+    }
+
+    public void setImageUrl(String imageUrl) {
+        mImageUrl = imageUrl;
     }
 
     public URI getImageURI() {
@@ -122,7 +179,8 @@ public class Card {
         SIDE_INFO_TEST_1,
         TEXT,
         CHARACTER,
-        GRID_SQUARE
+        GRID_SQUARE,
+        VIDEO_GRID
 
     }
 

--- a/app/src/main/java/android/support/v17/leanback/supportleanbackshowcase/models/VideoCard.java
+++ b/app/src/main/java/android/support/v17/leanback/supportleanbackshowcase/models/VideoCard.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2016 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package android.support.v17.leanback.supportleanbackshowcase.models;
+
+
+import com.google.gson.annotations.SerializedName;
+
+import java.io.Serializable;
+import android.support.v17.leanback.supportleanbackshowcase.R;
+
+/**
+ * The video card data structure used to hold the fields of each video card fetched from the
+ * url: {@link R.string.videos_url}
+ */
+public class VideoCard extends Card {
+
+    @SerializedName("sources") private String mVideoSource = "";
+    @SerializedName("background") private String mBackgroundUrl = "";
+    @SerializedName("studio") private String mStudio = "";
+
+    public VideoCard() {
+        super();
+        setType(Type.VIDEO_GRID);
+    }
+
+    public String getVideoSource() {
+        return mVideoSource;
+    }
+
+    public void setVideoSource(String sources) {
+        mVideoSource = sources;
+    }
+
+    public String getBackground() {
+        return mBackgroundUrl;
+    }
+
+    public void setBackground(String background) {
+        mBackgroundUrl = background;
+    }
+
+    public String getStudio() {
+        return mStudio;
+    }
+
+    public void setStudio(String studio) {
+        mStudio = studio;
+    }
+}

--- a/app/src/main/java/android/support/v17/leanback/supportleanbackshowcase/models/VideoRow.java
+++ b/app/src/main/java/android/support/v17/leanback/supportleanbackshowcase/models/VideoRow.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2016 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package android.support.v17.leanback.supportleanbackshowcase.models;
+
+import android.support.v17.leanback.supportleanbackshowcase.R;
+
+import com.google.gson.annotations.SerializedName;
+
+import java.util.List;
+
+/**
+ * This class represents a row of Video cards fetched from the
+ * url: {@link R.string.videos_url}
+ */
+public class VideoRow {
+    @SerializedName("category") private String mCategory = "";
+    @SerializedName("videos") private List<VideoCard> mVideos;
+
+    public String getCategory() {
+        return mCategory;
+    }
+
+    public void setCategory(String category) {
+        mCategory = category;
+    }
+
+    public List<VideoCard> getVideos() {
+        return mVideos;
+    }
+
+    public void setVideos(List<VideoCard> videos) {
+        mVideos = videos;
+    }
+}

--- a/app/src/main/res/layout/activity_video_grid_example.xml
+++ b/app/src/main/res/layout/activity_video_grid_example.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+     Copyright (C) 2016 The Android Open Source Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent">
+
+    <fragment
+        android:id="@+id/cardsFragment"
+        android:name="android.support.v17.leanback.supportleanbackshowcase.app.grid.VideoGridExampleFragment"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"></fragment>
+</RelativeLayout>

--- a/app/src/main/res/raw/launcher_cards.json
+++ b/app/src/main/res/raw/launcher_cards.json
@@ -19,47 +19,54 @@
       {
         "id": 2,
         "type": "DEFAULT",
-        "title": "Grid Examples",
+        "title": "Image Grid Examples",
         "localImageResource": "thumbnail_example_grid",
-        "description": "Showcase of various card design and layouts"
+        "description": "Showcase of various images in a vertical grid"
       },
       {
         "id": 3,
+        "type": "DEFAULT",
+        "title": "Video Grid Examples",
+        "localImageResource": "thumbnail_example_grid",
+        "description": "Showcase of various videos in a vertical grid"
+      },
+      {
+        "id": 4,
         "type": "DEFAULT",
         "title": "Detail Examples",
         "localImageResource": "thumbnail_example_detail",
         "description": "Showcase of various card design and layouts"
       },
       {
-        "id": 4,
+        "id": 5,
         "type": "DEFAULT",
         "title": "Video consumption Examples",
         "localImageResource": "thumbnail_example_video_consumption",
         "description": "Showcase of various card design and layouts"
       },
       {
-        "id": 5,
+        "id": 6,
         "type": "DEFAULT",
         "title": "Music consumption Examples",
         "localImageResource": "thumbnail_example_music_consumption",
         "description": "Showcase of various card design and layouts"
       },
       {
-        "id": 6,
+        "id": 7,
         "type": "DEFAULT",
         "title": "Wizard Examples",
         "localImageResource": "thumbnail_example_wizard",
         "description": "Showcase of various card design and layouts"
       },
       {
-        "id": 7,
+        "id": 8,
         "type": "DEFAULT",
         "title": "Settings Examples",
         "localImageResource": "thumbnail_example_settings",
         "description": "Showcase of various card design and layouts"
       },
       {
-        "id": 8,
+        "id": 9,
         "type": "DEFAULT",
         "title": "Dialog Examples",
         "localImageResource": "thumbnail_example_dialog",

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -22,7 +22,9 @@
     <string name="card_examples_title">Card Examples</string>
     <string name="detail_view_title">DetailView Example</string>
     <string name="action_cicked">Action clicked. Implement your own handler.</string>
-    <string name="grid_example_title">Grid Example</string>
+    <string name="grid_example_title">Image Grid Example</string>
+    <string name="video_grid_example_title">Video Grid Example</string>
+    <string name="videos_url">https://storage.googleapis.com/android-tv/android_tv_videos_new.json</string>
     <string name="action_buy">Buy </string>
     <string name="action_wishlist">Add to wishlist</string>
     <string name="action_related">Related</string>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -115,10 +115,21 @@
         <item name="cardBackground">@null</item>
     </style>
 
-    <!-- Theme corresponding to the GridCardTheme -->
+    <style name="VideoGridCardImageStyle" parent="Widget.Leanback.ImageCardView.ImageStyle">
+        <item name="android:layout_width">190dp</item>
+        <item name="android:layout_height">105dp</item>
+    </style>
+
+    <!-- Theme used for styling image cards in the vertical grid view -->
     <style name="GridCardTheme" parent="Theme.Leanback">
         <item name="imageCardViewStyle">@style/GridCardStyle</item>
         <item name="imageCardViewImageStyle">@style/GridCardImageStyle</item>
+    </style>
+
+    <!-- Theme used for styling video cards in the vertical grid view -->
+    <style name="VideoGridCardTheme" parent="Theme.Leanback">
+        <item name="imageCardViewStyle">@style/GridCardStyle</item>
+        <item name="imageCardViewImageStyle">@style/VideoGridCardImageStyle</item>
     </style>
 
     <!-- A default card style. Used in cards example. -->


### PR DESCRIPTION
Added a new card to the home screen that displays videos in a vertical
grid. The videos are fetched from a json URL and rendered using
ImageCardView presenter defined for a new VideoCard data model. Clicking
on each video card will launch a fresh instance of the playback activity.
Videos can be picture-in-pictured (PIP). For example, we can open one
video in PIP mode, while playing another one in full-screen.
