### PR TITLE
Music fragment: Fixed  the wraparound focus issue when hitting DPAD_R…

### DIFF
--- a/app/src/main/java/android/support/v17/leanback/supportleanbackshowcase/app/MainFragment.java
+++ b/app/src/main/java/android/support/v17/leanback/supportleanbackshowcase/app/MainFragment.java
@@ -87,7 +87,7 @@ public class MainFragment extends BrowseFragment {
 
     private void setupUIElements() {
         setTitle(getString(R.string.browse_title));
-        setBadgeDrawable(getResources().getDrawable(R.drawable.title_android_tv, null));
+        setBadgeDrawable(getResources().getDrawable(R.drawable.title_android_tv));
         setHeadersState(HEADERS_DISABLED);
         setHeadersTransitionOnBackEnabled(false);
         setBrandColor(getResources().getColor(R.color.fastlane_background));

--- a/app/src/main/java/android/support/v17/leanback/supportleanbackshowcase/app/media/MusicExampleActivity.java
+++ b/app/src/main/java/android/support/v17/leanback/supportleanbackshowcase/app/media/MusicExampleActivity.java
@@ -14,14 +14,14 @@
 
 package android.support.v17.leanback.supportleanbackshowcase.app.media;
 
-import android.app.Activity;
 import android.os.Bundle;
 import android.support.v17.leanback.supportleanbackshowcase.R;
+import android.support.v4.app.FragmentActivity;
 
 /**
  * TODO: Javadoc
  */
-public class MusicExampleActivity extends Activity {
+public class MusicExampleActivity extends FragmentActivity {
 
     @Override public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);

--- a/app/src/main/java/android/support/v17/leanback/supportleanbackshowcase/app/media/MusicPlaybackService.java
+++ b/app/src/main/java/android/support/v17/leanback/supportleanbackshowcase/app/media/MusicPlaybackService.java
@@ -22,10 +22,7 @@ import android.content.Intent;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.media.AudioManager;
-import android.media.MediaMetadata;
 import android.media.MediaPlayer;
-import android.media.session.MediaSession;
-import android.media.session.PlaybackState;
 import android.os.Binder;
 import android.os.Handler;
 import android.os.IBinder;
@@ -38,6 +35,10 @@ import android.view.KeyEvent;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import android.support.v4.media.session.MediaSessionCompat;
+import android.support.v4.media.MediaMetadataCompat;
+import android.support.v4.media.session.PlaybackStateCompat;
+import android.support.v4.media.session.MediaControllerCompat;
 
 /**
  * Music service that handles all the interactions between the app and the media player. It receives
@@ -61,7 +62,7 @@ public class MusicPlaybackService extends Service {
 
     private MediaPlayer mPlayer;
     // MediaSession created for communication between NowPlayingCard in the launcher and the current MediaPlayer state
-    private MediaSession mMediaSession;
+    private MediaSessionCompat mMediaSession;
 
     private static final String TAG = "MusicPlaybackService";
     int mCurrentMediaPosition = -1;
@@ -175,9 +176,9 @@ public class MusicPlaybackService extends Service {
             mPlayer = new MediaPlayer();
         }
         if (mMediaSession == null) {
-            mMediaSession = new MediaSession(this, "MusicPlayer Session");
-            mMediaSession.setFlags(MediaSession.FLAG_HANDLES_MEDIA_BUTTONS |
-                    MediaSession.FLAG_HANDLES_TRANSPORT_CONTROLS);
+            mMediaSession = new MediaSessionCompat(this, "MusicPlayer Session");
+            mMediaSession.setFlags(MediaSessionCompat.FLAG_HANDLES_MEDIA_BUTTONS |
+                    MediaSessionCompat.FLAG_HANDLES_TRANSPORT_CONTROLS);
             mMediaSession.setCallback(new MediaSessionCallback());
             updateMediaSessionIntent();
         }
@@ -281,6 +282,7 @@ public class MusicPlaybackService extends Service {
         mPlayer.setOnCompletionListener(new MediaPlayer.OnCompletionListener() {
             @Override public void onCompletion(MediaPlayer mp) {
                 updateMediaSessionPlayState();
+                notifyMediaStateChanged(MediaUtils.MEDIA_STATE_COMPLETED);
                 if (mRepeatState == MEDIA_ACTION_REPEAT_ALL &&
                         mCurrentMediaPosition == mMediaItemList.size() - 1) {
                     // The last media item is played and repeatAll action is enabled;
@@ -317,34 +319,34 @@ public class MusicPlaybackService extends Service {
             throw new IllegalArgumentException(
                     "mCurrentMediaItem is null in updateMediaSessionMetaData!");
         }
-        MediaMetadata.Builder metaDataBuilder = new MediaMetadata.Builder();
+        MediaMetadataCompat.Builder metaDataBuilder = new MediaMetadataCompat.Builder();
         if (mCurrentMediaItem.getMediaTitle() != null) {
-            metaDataBuilder.putString(MediaMetadata.METADATA_KEY_TITLE,
+            metaDataBuilder.putString(MediaMetadataCompat.METADATA_KEY_TITLE,
                     mCurrentMediaItem.getMediaTitle());
         }
         if (mCurrentMediaItem.getMediaAlbumName() != null) {
-            metaDataBuilder.putString(MediaMetadata.METADATA_KEY_ALBUM,
+            metaDataBuilder.putString(MediaMetadataCompat.METADATA_KEY_ALBUM,
                     mCurrentMediaItem.getMediaAlbumName());
         }
         if (mCurrentMediaItem.getMediaArtistName() != null) {
-            metaDataBuilder.putString(MediaMetadata.METADATA_KEY_ARTIST,
+            metaDataBuilder.putString(MediaMetadataCompat.METADATA_KEY_ARTIST,
                     mCurrentMediaItem.getMediaArtistName());
         }
         if (mCurrentMediaItem.getMediaAlbumArtResId() != 0) {
             Bitmap albumArtBitmap = BitmapFactory.decodeResource(getResources(),
                     mCurrentMediaItem.getMediaAlbumArtResId());
-            metaDataBuilder.putBitmap(MediaMetadata.METADATA_KEY_ALBUM_ART, albumArtBitmap);
+            metaDataBuilder.putBitmap(MediaMetadataCompat.METADATA_KEY_ALBUM_ART, albumArtBitmap);
         }
         mMediaSession.setMetadata(metaDataBuilder.build());
     }
 
     private void updateMediaSessionPlayState() {
-        PlaybackState.Builder playbackStateBuilder = new PlaybackState.Builder();
+        PlaybackStateCompat.Builder playbackStateBuilder = new PlaybackStateCompat.Builder();
         int playState;
         if (isPlaying()) {
-            playState = PlaybackState.STATE_PLAYING;
+            playState = PlaybackStateCompat.STATE_PLAYING;
         } else {
-            playState = PlaybackState.STATE_PAUSED;
+            playState = PlaybackStateCompat.STATE_PAUSED;
         }
         long currentPosition = getCurrentPosition();
         playbackStateBuilder.setState(playState, currentPosition, (float) 1.0).setActions(
@@ -371,13 +373,13 @@ public class MusicPlaybackService extends Service {
     /**
      * @return The available set of actions for the media session. These actions should be provided
      * for the MediaSession PlaybackState in order for
-     * {@link MediaSession.Callback#onMediaButtonEvent} to call relevant methods of onPause() or
+     * {@link MediaSessionCompat.Callback#onMediaButtonEvent} to call relevant methods of onPause() or
      * onPlay().
      */
     private long getPlaybackStateActions() {
-        return PlaybackState.ACTION_PLAY | PlaybackState.ACTION_PAUSE |
-                PlaybackState.ACTION_FAST_FORWARD | PlaybackState.ACTION_REWIND |
-                PlaybackState.ACTION_SKIP_TO_NEXT | PlaybackState.ACTION_SKIP_TO_PREVIOUS;
+        return PlaybackStateCompat.ACTION_PLAY | PlaybackStateCompat.ACTION_PAUSE |
+                PlaybackStateCompat.ACTION_FAST_FORWARD | PlaybackStateCompat.ACTION_REWIND |
+                PlaybackStateCompat.ACTION_SKIP_TO_NEXT | PlaybackStateCompat.ACTION_SKIP_TO_PREVIOUS;
     }
 
     public void reset() {
@@ -494,7 +496,7 @@ public class MusicPlaybackService extends Service {
         return mBinder;
     }
 
-    private class MediaSessionCallback extends MediaSession.Callback {
+    private class MediaSessionCallback extends MediaSessionCompat.Callback {
 
         @Override
         public boolean onMediaButtonEvent(Intent mediaButtonIntent) {

--- a/app/src/main/java/android/support/v17/leanback/supportleanbackshowcase/app/media/VideoConsumptionExampleFragment.java
+++ b/app/src/main/java/android/support/v17/leanback/supportleanbackshowcase/app/media/VideoConsumptionExampleFragment.java
@@ -14,11 +14,15 @@
 
 package android.support.v17.leanback.supportleanbackshowcase.app.media;
 
-import android.app.Fragment;
+import android.os.Build;
+import android.support.v17.leanback.app.PlaybackControlGlue;
+import android.support.v17.leanback.app.PlaybackControlSupportGlue;
+import android.support.v4.app.Fragment;
 import android.content.Intent;
 import android.media.session.MediaSession;
 import android.os.Bundle;
 import android.support.v17.leanback.app.PlaybackOverlayFragment;
+import android.support.v17.leanback.app.PlaybackOverlaySupportFragment;
 import android.support.v17.leanback.widget.Action;
 import android.support.v17.leanback.widget.ArrayObjectAdapter;
 import android.support.v17.leanback.widget.OnItemViewClickedListener;
@@ -33,7 +37,7 @@ import android.view.SurfaceHolder;
 import android.view.SurfaceView;
 
 
-public class VideoConsumptionExampleFragment extends PlaybackOverlayFragment implements
+public class VideoConsumptionExampleFragment extends PlaybackOverlaySupportFragment implements
         OnItemViewClickedListener, MediaPlayerGlue.OnMediaStateChangeListener {
 
     private static final String URL = "http://techslides.com/demos/sample-videos/small.mp4";
@@ -45,7 +49,7 @@ public class VideoConsumptionExampleFragment extends PlaybackOverlayFragment imp
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
-        mGlue = new VideoMediaPlayerGlue(getActivity(), this) {
+        mGlue = new VideoMediaPlayerGlue(getActivity(), this, getActivity()) {
 
             @Override
             protected void onRowChanged(PlaybackControlsRow row) {
@@ -113,7 +117,8 @@ public class VideoConsumptionExampleFragment extends PlaybackOverlayFragment imp
             currentMetaData.setMediaSourcePath(URL);
         }
         mGlue.setOnMediaFileFinishedPlayingListener(this);
-        mGlue.prepareIfNeededAndPlay(currentMetaData);
+        mGlue.prepareIfNeededAndPlay(PlaybackControlSupportGlue.PLAYBACK_SPEED_NORMAL,
+                currentMetaData);
     }
 
     @Override
@@ -121,13 +126,14 @@ public class VideoConsumptionExampleFragment extends PlaybackOverlayFragment imp
         // Enabling the video stay visible and play in the background when home screen is pressed.
         // (gregarious mode)
         if (mGlue.isMediaPlaying()) {
-            boolean isVisibleBehind = getActivity().requestVisibleBehind(true);
+            boolean isVisibleBehind = (Build.VERSION.SDK_INT >= 21) &&
+                    getActivity().requestVisibleBehind(true);
             boolean isPictureInPictureMode = VideoExampleActivity.supportsPictureInPicture(
                     getContext()) && getActivity().isInPictureInPictureMode();
             if (!isVisibleBehind && !isPictureInPictureMode) {
                 mGlue.pausePlayback();
             }
-        } else {
+        } else if (Build.VERSION.SDK_INT >= 21) {
             getActivity().requestVisibleBehind(false);
         }
         super.onPause();

--- a/app/src/main/java/android/support/v17/leanback/supportleanbackshowcase/app/media/VideoExampleActivity.java
+++ b/app/src/main/java/android/support/v17/leanback/supportleanbackshowcase/app/media/VideoExampleActivity.java
@@ -14,8 +14,8 @@
 
 package android.support.v17.leanback.supportleanbackshowcase.app.media;
 
-import android.app.Activity;
-import android.app.FragmentTransaction;
+import android.support.v4.app.FragmentActivity;
+import android.support.v4.app.FragmentTransaction;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
@@ -26,7 +26,7 @@ import android.support.v4.os.BuildCompat;
 /**
  * TODO: Javadoc
  */
-public class VideoExampleActivity extends Activity {
+public class VideoExampleActivity extends FragmentActivity {
 
     public static final String TAG = "VideoExampleActivity";
 
@@ -35,11 +35,11 @@ public class VideoExampleActivity extends Activity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_video_example);
 
-        FragmentTransaction ft1 = getFragmentManager().beginTransaction();
+        FragmentTransaction ft1 = getSupportFragmentManager().beginTransaction();
         ft1.replace(R.id.videoFragment, new VideoSurfaceFragment(), VideoSurfaceFragment.TAG);
         ft1.commit();
 
-        FragmentTransaction ft2 = getFragmentManager().beginTransaction();
+        FragmentTransaction ft2 = getSupportFragmentManager().beginTransaction();
         ft2.add(R.id.videoFragment, new VideoConsumptionExampleFragment(), VideoConsumptionExampleFragment.TAG);
         ft2.commit();
     }

--- a/app/src/main/java/android/support/v17/leanback/supportleanbackshowcase/app/media/VideoMediaPlayerGlue.java
+++ b/app/src/main/java/android/support/v17/leanback/supportleanbackshowcase/app/media/VideoMediaPlayerGlue.java
@@ -25,13 +25,10 @@ import android.content.res.Resources;
 import android.graphics.Bitmap;
 import android.graphics.Color;
 import android.media.AudioManager;
-import android.media.MediaMetadata;
 import android.media.MediaPlayer;
-import android.media.session.MediaController;
-import android.media.session.MediaSession;
-import android.media.session.PlaybackState;
 import android.net.Uri;
-import android.support.v17.leanback.app.PlaybackOverlayFragment;
+import android.os.RemoteException;
+import android.support.v17.leanback.app.PlaybackOverlaySupportFragment;
 import android.support.v17.leanback.supportleanbackshowcase.R;
 import android.support.v17.leanback.widget.Action;
 import android.support.v17.leanback.widget.ArrayObjectAdapter;
@@ -46,7 +43,11 @@ import com.bumptech.glide.request.animation.GlideAnimation;
 import com.bumptech.glide.request.target.SimpleTarget;
 
 import java.io.IOException;
-import java.util.List;
+import android.support.v4.media.session.MediaSessionCompat;
+import android.support.v4.media.MediaMetadataCompat;
+import android.support.v4.media.session.PlaybackStateCompat;
+import android.support.v4.media.session.MediaControllerCompat;
+import android.support.v4.app.FragmentActivity;
 
 /**<p>>
  * This glue extends the {@link MediaPlayerGlue} and handles all the
@@ -63,13 +64,14 @@ public abstract class VideoMediaPlayerGlue extends MediaPlayerGlue implements
     private MediaPlayer mPlayer;
     // MediaSession required for receiving input focus while in PIP mode or homescreen.
     // The framework also needs it for displaying NowPlayingCard on the homescreen
-    private MediaSession mVideoSession;
+    private MediaSessionCompat mVideoSession;
     private AudioManager mAudioManager;
     int mAudioFocus = AudioManager.AUDIOFOCUS_LOSS;
     private static final String TAG = "VideoMediaPlayerGlue";
 
-    public VideoMediaPlayerGlue(Context context, PlaybackOverlayFragment fragment) {
-        super(context, fragment);
+    public VideoMediaPlayerGlue(Context context, PlaybackOverlaySupportFragment fragment,
+                                FragmentActivity activity) {
+        super(context, fragment, activity);
 
         createMediaPlayerIfNeeded();
         mAudioManager = (AudioManager) getContext().getSystemService(Context.AUDIO_SERVICE);
@@ -92,7 +94,8 @@ public abstract class VideoMediaPlayerGlue extends MediaPlayerGlue implements
         super.onActionClicked(action);
         if (action == mClosedCaptioningAction) {
             mClosedCaptioningAction.nextIndex();
-        } else if (action == mPipAction) {
+        } else if (action == mPipAction && VideoExampleActivity.supportsPictureInPicture(
+                getContext()) ) {
             ((Activity) getContext()).enterPictureInPictureMode();
         }
     }
@@ -117,17 +120,17 @@ public abstract class VideoMediaPlayerGlue extends MediaPlayerGlue implements
             throw new IllegalArgumentException(
                     "mCurrentMediaItem is null in updateMediaSessionMetaData!");
         }
-        final MediaMetadata.Builder metaDataBuilder = new MediaMetadata.Builder();
+        final MediaMetadataCompat.Builder metaDataBuilder = new MediaMetadataCompat.Builder();
         if (mMediaMetaData.getMediaTitle() != null) {
-            metaDataBuilder.putString(MediaMetadata.METADATA_KEY_TITLE,
+            metaDataBuilder.putString(MediaMetadataCompat.METADATA_KEY_TITLE,
                     mMediaMetaData.getMediaTitle());
         }
         if (mMediaMetaData.getMediaAlbumName() != null) {
-            metaDataBuilder.putString(MediaMetadata.METADATA_KEY_ALBUM,
+            metaDataBuilder.putString(MediaMetadataCompat.METADATA_KEY_ALBUM,
                     mMediaMetaData.getMediaAlbumName());
         }
         if (mMediaMetaData.getMediaArtistName() != null) {
-            metaDataBuilder.putString(MediaMetadata.METADATA_KEY_ARTIST,
+            metaDataBuilder.putString(MediaMetadataCompat.METADATA_KEY_ARTIST,
                    mMediaMetaData.getMediaArtistName());
         }
         Resources res = getContext().getResources();
@@ -142,7 +145,7 @@ public abstract class VideoMediaPlayerGlue extends MediaPlayerGlue implements
                               public void onResourceReady(
                                       Bitmap resource,
                                       GlideAnimation<? super Bitmap> glideAnimation) {
-                                  metaDataBuilder.putBitmap(MediaMetadata.METADATA_KEY_ALBUM_ART,
+                                  metaDataBuilder.putBitmap(MediaMetadataCompat.METADATA_KEY_ALBUM_ART,
                                           resource);
                                   mVideoSession.setMetadata(metaDataBuilder.build());
                               }
@@ -161,7 +164,7 @@ public abstract class VideoMediaPlayerGlue extends MediaPlayerGlue implements
             // MediaSession has already been released, no need to update PlaybackState
             return;
         }
-        PlaybackState.Builder playbackStateBuilder = new PlaybackState.Builder();
+        PlaybackStateCompat.Builder playbackStateBuilder = new PlaybackStateCompat.Builder();
         long currentPosition = getCurrentPosition();
         playbackStateBuilder.setState(playbackState, currentPosition, (float) 1.0).setActions(
                 getPlaybackStateActions()
@@ -192,9 +195,9 @@ public abstract class VideoMediaPlayerGlue extends MediaPlayerGlue implements
      * be displayed in the list of PIP controls.
      */
     private long getPlaybackStateActions() {
-        return PlaybackState.ACTION_PLAY | PlaybackState.ACTION_PAUSE |
-                PlaybackState.ACTION_FAST_FORWARD | PlaybackState.ACTION_REWIND |
-                PlaybackState.ACTION_SKIP_TO_NEXT | PlaybackState.ACTION_SKIP_TO_PREVIOUS;
+        return PlaybackStateCompat.ACTION_PLAY | PlaybackStateCompat.ACTION_PAUSE |
+                PlaybackStateCompat.ACTION_FAST_FORWARD | PlaybackStateCompat.ACTION_REWIND |
+                PlaybackStateCompat.ACTION_SKIP_TO_NEXT | PlaybackStateCompat.ACTION_SKIP_TO_PREVIOUS;
     }
 
     /**
@@ -223,13 +226,14 @@ public abstract class VideoMediaPlayerGlue extends MediaPlayerGlue implements
             Log.e(TAG, "Video player could not obtain audio focus in startPlayback");
             return;
         }
-        prepareIfNeededAndPlay(mMediaMetaData);
+        prepareIfNeededAndPlay(speed, mMediaMetaData);
     }
 
     @Override protected void pausePlayback() {
+        super.pausePlayback();
         if (isMediaPlaying()) {
             mPlayer.pause();
-            updateVideoSessionPlayState(PlaybackState.STATE_PAUSED);
+            updateVideoSessionPlayState(PlaybackStateCompat.STATE_PAUSED);
         }
     }
 
@@ -246,7 +250,8 @@ public abstract class VideoMediaPlayerGlue extends MediaPlayerGlue implements
         }
     }
 
-    public void prepareIfNeededAndPlay(MediaMetaData mediaMetaData) {
+    public void prepareIfNeededAndPlay(int speed, MediaMetaData mediaMetaData) {
+        super.startPlayback(speed);
         if (mediaMetaData == null) {
             throw new RuntimeException("Provided metadata is null!");
         }
@@ -264,7 +269,7 @@ public abstract class VideoMediaPlayerGlue extends MediaPlayerGlue implements
                 // No need to reset the player.
                 Log.d(TAG, "mPlayer is started (meta data is the same)");
                 mPlayer.start();
-                updateVideoSessionPlayState(PlaybackState.STATE_PLAYING);
+                updateVideoSessionPlayState(PlaybackStateCompat.STATE_PLAYING);
                 onStateChanged();
             }
         } else {
@@ -318,7 +323,7 @@ public abstract class VideoMediaPlayerGlue extends MediaPlayerGlue implements
             @Override public void onPrepared(MediaPlayer mp) {
                 mInitialized = true;
                 mPlayer.start();
-                updateVideoSessionPlayState(PlaybackState.STATE_PLAYING);
+                updateVideoSessionPlayState(PlaybackStateCompat.STATE_PLAYING);
                 updateVideoSessionMetaData();
                 onMetadataChanged();
                 onStateChanged();
@@ -327,6 +332,7 @@ public abstract class VideoMediaPlayerGlue extends MediaPlayerGlue implements
         });
         mPlayer.setOnCompletionListener(new MediaPlayer.OnCompletionListener() {
             @Override public void onCompletion(MediaPlayer mp) {
+                onMediaItemComplete();
                 if (mInitialized && mMediaFileStateChangeListener != null)
                     mMediaFileStateChangeListener.onMediaStateChanged(mediaMetaData,
                             MediaUtils.MEDIA_STATE_COMPLETED);
@@ -347,7 +353,7 @@ public abstract class VideoMediaPlayerGlue extends MediaPlayerGlue implements
             }
         });
         mPlayer.prepareAsync();
-        updateVideoSessionPlayState(PlaybackState.STATE_BUFFERING);
+        updateVideoSessionPlayState(PlaybackStateCompat.STATE_BUFFERING);
         onStateChanged();
     }
 
@@ -358,7 +364,7 @@ public abstract class VideoMediaPlayerGlue extends MediaPlayerGlue implements
         mInitialized = false;
         if (mPlayer != null) {
             mPlayer.reset();
-            updateVideoSessionPlayState(PlaybackState.STATE_PAUSED);
+            updateVideoSessionPlayState(PlaybackStateCompat.STATE_PAUSED);
         }
     }
 
@@ -385,19 +391,24 @@ public abstract class VideoMediaPlayerGlue extends MediaPlayerGlue implements
 
     public void createMediaSessionIfNeeded() {
         if (mVideoSession == null) {
-            mVideoSession = new MediaSession(this.getContext(), "VideoPlayer Session");
-            mVideoSession.setFlags(MediaSession.FLAG_HANDLES_MEDIA_BUTTONS |
-                    MediaSession.FLAG_HANDLES_TRANSPORT_CONTROLS);
+            mVideoSession = new MediaSessionCompat(this.getContext(), "VideoPlayer Session");
+            mVideoSession.setFlags(MediaSessionCompat.FLAG_HANDLES_MEDIA_BUTTONS |
+                    MediaSessionCompat.FLAG_HANDLES_TRANSPORT_CONTROLS);
             mVideoSession.setCallback(new VideoSessionCallback());
             mVideoSession.setActive(true);
-            updateVideoSessionPlayState(PlaybackState.STATE_NONE);
-            getFragment().getActivity().setMediaController(
-                    new MediaController(getContext(), mVideoSession.getSessionToken()));
+            updateVideoSessionPlayState(PlaybackStateCompat.STATE_NONE);
+            try {
+                mActivity.setSupportMediaController(
+                        new MediaControllerCompat(getContext(), mVideoSession.getSessionToken()));
+            } catch (RemoteException ex) {
+                Log.e(TAG, "Could not connected media controller to the activity.");
+            }
+
         }
     }
 
     /**
-     * Releases the {@link MediaSession}. The media session is released when the playback fragment
+     * Releases the {@link MediaSessionCompat}. The media session is released when the playback fragment
      * is no longer visible. This can happen in onStop() or surfaceDestroyed() (The ordering of these
      * two is not deterministic, and that's why it's important to release the session in both callbacks).
      * Since the media session can be released without the fragment being destroyed,
@@ -432,7 +443,7 @@ public abstract class VideoMediaPlayerGlue extends MediaPlayerGlue implements
                 break;
         }
     }
-    private class VideoSessionCallback extends MediaSession.Callback {
+    private class VideoSessionCallback extends MediaSessionCompat.Callback {
 
         @Override
         public boolean onMediaButtonEvent(Intent mediaButtonIntent) {

--- a/app/src/main/java/android/support/v17/leanback/supportleanbackshowcase/app/media/VideoSurfaceFragment.java
+++ b/app/src/main/java/android/support/v17/leanback/supportleanbackshowcase/app/media/VideoSurfaceFragment.java
@@ -14,7 +14,7 @@
 
 package android.support.v17.leanback.supportleanbackshowcase.app.media;
 
-import android.app.Fragment;
+import android.support.v4.app.Fragment;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.support.v17.leanback.supportleanbackshowcase.R;

--- a/app/src/main/java/android/support/v17/leanback/supportleanbackshowcase/app/settings/SettingsExampleFragment.java
+++ b/app/src/main/java/android/support/v17/leanback/supportleanbackshowcase/app/settings/SettingsExampleFragment.java
@@ -32,7 +32,7 @@ import java.util.Stack;
 
 public class SettingsExampleFragment extends LeanbackSettingsFragment implements DialogPreference.TargetFragment {
 
-    private final Stack<Fragment> fragments = new Stack<Fragment>();
+    protected final Stack<Fragment> fragments = new Stack<Fragment>();
 
     @Override
     public void onPreferenceStartInitialScreen() {
@@ -60,6 +60,7 @@ public class SettingsExampleFragment extends LeanbackSettingsFragment implements
 
     private PreferenceFragment buildPreferenceFragment(int preferenceResId, String root) {
         PreferenceFragment fragment = new PrefFragment();
+        fragment.setTargetFragment(SettingsExampleFragment.this, 0);
         Bundle args = new Bundle();
         args.putInt("preferenceResource", preferenceResId);
         args.putString("root", root);
@@ -67,7 +68,14 @@ public class SettingsExampleFragment extends LeanbackSettingsFragment implements
         return fragment;
     }
 
-    private class PrefFragment extends LeanbackPreferenceFragment {
+    public static class PrefFragment extends LeanbackPreferenceFragment {
+
+        SettingsExampleFragment mOuterFragment;
+
+        @Override
+        public void onCreate(Bundle savedInstanceState) {
+            super.onCreate(savedInstanceState);
+        }
 
         @Override
         public void onCreatePreferences(Bundle bundle, String s) {
@@ -94,13 +102,14 @@ public class SettingsExampleFragment extends LeanbackSettingsFragment implements
 
         @Override
         public void onAttach(Context context) {
-            fragments.push(this);
+            mOuterFragment = (SettingsExampleFragment) getTargetFragment();
+            mOuterFragment.fragments.push(this);
             super.onAttach(context);
         }
 
         @Override
         public void onDetach() {
-            fragments.pop();
+            mOuterFragment.fragments.pop();
             super.onDetach();
         }
     }

--- a/app/src/main/java/android/support/v17/leanback/supportleanbackshowcase/models/Song.java
+++ b/app/src/main/java/android/support/v17/leanback/supportleanbackshowcase/models/Song.java
@@ -18,6 +18,7 @@ package android.support.v17.leanback.supportleanbackshowcase.models;
 import android.content.Context;
 import android.graphics.drawable.Drawable;
 import android.support.v17.leanback.supportleanbackshowcase.R;
+import android.support.v17.leanback.widget.AbstractMediaItemPresenter;
 import android.support.v17.leanback.widget.BaseOnItemViewSelectedListener;
 import android.support.v17.leanback.widget.MultiActionsProvider;
 import android.support.v17.leanback.widget.Row;
@@ -41,6 +42,7 @@ public class Song implements MultiActionsProvider {
     @SerializedName("duration") private String mDuration = null;
     @SerializedName("number") private int mNumber = 0;
     @SerializedName("favorite") private boolean mFavorite = false;
+    private int mPlayState = AbstractMediaItemPresenter.PLAY_STATE_INITIAL;
 
     private MultiAction[] mMediaRowActions;
 
@@ -91,6 +93,15 @@ public class Song implements MultiActionsProvider {
 
     public void setFavorite(boolean favorite) {
         mFavorite = favorite;
+    }
+
+
+    public int getPlayState() {
+        return mPlayState;
+    }
+
+    public void setPlayState(int playState) {
+        mPlayState = playState;
     }
 
     public int getFileResource(Context context) {

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -237,7 +237,14 @@
         <!-- Ensures that the focus does not wrap around when pressing DPAD_RIGHT from the last view
         within a row. By default, VerticalGridView wraps around if this attribute is not explicitly
         set -->
-        <item name="focusOutSideEnd">false</item>
+    </style>
+
+    <style name="Widget.Leanback.PlaybackMediaItemNumberViewFlipperStyle.Visible">
+        <item name="android:visibility">visible</item>
+    </style>
+
+    <style name="Widget.Leanback.PlaybackMediaItemDurationStyle.Visible">
+        <item name="android:visibility">visible</item>
     </style>
 
     <style name="RegularMediaItemTextStyle" parent="TextAppearance.Leanback.PlaybackMediaItemNumber">
@@ -254,9 +261,9 @@
     <style name="RegularMediaItemNameStyle" parent="Widget.Leanback.PlaybackMediaItemNameStyle">
     </style>
 
-    <style name="RegularMediaItemDurationStyle" parent="Widget.Leanback.PlaybackMediaItemDurationStyle">
-        <item name="android:visibility">visible</item>
-    </style>
+    <!--<style name="RegularMediaItemDurationStyle" parent="Widget.Leanback.PlaybackMediaItemDurationStyle">-->
+        <!--<item name="android:visibility">visible</item>-->
+    <!--</style>-->
 
 
     <style name="FavoriteMediaItemTextStyle" parent="TextAppearance.Leanback.PlaybackMediaItemNumber">
@@ -275,7 +282,7 @@
     </style>
 
     <style name="FavoriteMediaItemDurationStyle" parent="Widget.Leanback.PlaybackMediaItemDurationStyle">
-        <item name="android:visibility">visible</item>
+        <!--<item name="android:visibility">visible</item>-->
         <item name="android:textAppearance">@style/FavoriteMediaItemTextStyle</item>
     </style>
 

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -233,6 +233,13 @@
         <item name="android:background">#282248</item>
     </style>
 
+    <style name="Widget.Leanback.Rows.VerticalGridView.NoFocusOutSideEnd">
+        <!-- Ensures that the focus does not wrap around when pressing DPAD_RIGHT from the last view
+        within a row. By default, VerticalGridView wraps around if this attribute is not explicitly
+        set -->
+        <item name="focusOutSideEnd">false</item>
+    </style>
+
     <style name="RegularMediaItemTextStyle" parent="TextAppearance.Leanback.PlaybackMediaItemNumber">
         <item name="android:textColor">#FF6255</item>
         <item name="android:textSize">18sp</item>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -71,6 +71,7 @@
 
     <style name="Theme.Example.LeanbackMusic" parent="Theme.Example.Leanback">
         <item name="android:windowBackground">@drawable/background_sax</item>
+        <item name="rowsVerticalGridStyle">@style/Widget.Leanback.Rows.VerticalGridView.NoFocusOutSideEnd</item>
      </style>
 
     <style name="Theme.Example.LeanbackMusic.RegularSongNumbers">

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -61,7 +61,9 @@
         <item name="android:windowIsTranslucent">true</item>
         <item name="android:windowBackground">@android:color/transparent</item>
         <item name="android:backgroundDimEnabled">true</item>
-        <item name="android:colorPrimary">@color/settings_background</item>
+        <!--<item name="android:colorPrimary">@color/settings_background</item>-->
+        <item name="defaultBrandColor">#F0F0</item>
+        <item name="android:colorAccent">?attr/defaultBrandColor</item>
     </style>
 
     <style name="Theme.Example.LeanbackDetails" parent="Theme.Leanback.Details">
@@ -72,18 +74,19 @@
     <style name="Theme.Example.LeanbackMusic" parent="Theme.Example.Leanback">
         <item name="android:windowBackground">@drawable/background_sax</item>
         <item name="rowsVerticalGridStyle">@style/Widget.Leanback.Rows.VerticalGridView.NoFocusOutSideEnd</item>
+        <item name="playbackMediaItemNumberViewFlipperStyle">@style/Widget.Leanback.PlaybackMediaItemNumberViewFlipperStyle.Visible</item>
      </style>
 
     <style name="Theme.Example.LeanbackMusic.RegularSongNumbers">
         <item name="playbackMediaItemNumberStyle">@style/RegularMediaItemNumberStyle</item>
         <item name="playbackMediaItemNameStyle">@style/RegularMediaItemNameStyle</item>
-        <item name="playbackMediaItemDurationStyle">@style/RegularMediaItemDurationStyle</item>
+        <item name="playbackMediaItemDurationStyle">@style/Widget.Leanback.PlaybackMediaItemDurationStyle.Visible</item>
     </style>
 
     <style name="Theme.Example.LeanbackMusic.FavoriteSongNumbers">
         <item name="playbackMediaItemNumberStyle">@style/FavoriteMediaItemNumberStyle</item>
         <item name="playbackMediaItemNameStyle">@style/FavoriteMediaItemNameStyle</item>
-        <item name="playbackMediaItemDurationStyle">@style/FavoriteMediaItemDurationStyle</item>
+        <item name="playbackMediaItemDurationStyle">@style/Widget.Leanback.PlaybackMediaItemDurationStyle.Visible</item>
     </style>
 
     <style name="Theme.Example.LeanbackMusic.TrackListHeader">


### PR DESCRIPTION
…IGHT

In the music playlist, when the focus reached the last item, hitting
DPAD_RIGHT wrapped the focus back to the first view of the row. Fixed it
by disabaling focusOutSideEnd in VerticalGridView.
