### PR TITLE
Fixed overlapping Title with WebView Fragment.

### DIFF
--- a/app/src/main/java/android/support/v17/leanback/supportleanbackshowcase/app/page/PageAndListRowFragment.java
+++ b/app/src/main/java/android/support/v17/leanback/supportleanbackshowcase/app/page/PageAndListRowFragment.java
@@ -314,6 +314,12 @@ public class PageAndListRowFragment extends BrowseFragment {
         }
 
         @Override
+        public void onCreate(Bundle savedInstanceState) {
+            super.onCreate(savedInstanceState);
+            getMainFragmentAdapter().getFragmentHost().showTitleView(false);
+        }
+
+        @Override
         public View onCreateView(
                 LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
             FrameLayout root = new FrameLayout(getActivity());


### PR DESCRIPTION
Hid TitleView in onCreate() of WebViewFragment.
