### PR TITLE
Fix forward and rewind buttons in Music Consumption Examples

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 24
-    buildToolsVersion "24"
+    compileSdkVersion 25
+    buildToolsVersion "25"
 
     defaultConfig {
         applicationId "android.support.v17.leanback.supportleanbackshowcase"
         minSdkVersion '17'
-        targetSdkVersion '24'
+        targetSdkVersion '25'
         versionCode 1
         versionName "1.0"
         multiDexEnabled true
@@ -33,7 +33,7 @@ dependencies {
     compile "com.google.code.gson:gson:1.7.2"
     compile "com.squareup.picasso:picasso:2.3.2"
     compile "com.android.support:palette-v7:+"
-    
+
     compile 'com.github.bumptech.glide:glide:3.7.0'
 
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -54,6 +54,10 @@
             android:exported="true"
             android:theme="@style/Theme.Example.LeanbackDetails"/>
         <activity
+            android:name=".app.details.DetailViewExampleWithVideoBackgroundActivity"
+            android:exported="true"
+            android:theme="@style/Theme.Example.LeanbackDetails"/>
+        <activity
             android:name=".app.cards.CardExampleActivity"
             android:exported="true"
             android:theme="@style/Theme.Example.LeanbackBrowse"/>

--- a/app/src/main/java/android/support/v17/leanback/supportleanbackshowcase/app/MainFragment.java
+++ b/app/src/main/java/android/support/v17/leanback/supportleanbackshowcase/app/MainFragment.java
@@ -20,6 +20,7 @@ import android.support.v17.leanback.app.BrowseFragment;
 import android.support.v17.leanback.supportleanbackshowcase.R;
 import android.support.v17.leanback.supportleanbackshowcase.app.cards.CardExampleActivity;
 import android.support.v17.leanback.supportleanbackshowcase.app.details.DetailViewExampleActivity;
+import android.support.v17.leanback.supportleanbackshowcase.app.details.DetailViewExampleWithVideoBackgroundActivity;
 import android.support.v17.leanback.supportleanbackshowcase.app.dialog.DialogExampleActivity;
 import android.support.v17.leanback.supportleanbackshowcase.app.grid.GridExampleActivity;
 import android.support.v17.leanback.supportleanbackshowcase.app.grid.VideoGridExampleActivity;
@@ -133,15 +134,20 @@ public class MainFragment extends BrowseFragment {
                 }
                 case 5: {
                     intent = new Intent(getActivity().getBaseContext(),
-                            VideoExampleActivity.class);
+                            DetailViewExampleWithVideoBackgroundActivity.class);
                     break;
                 }
                 case 6: {
                     intent = new Intent(getActivity().getBaseContext(),
-                            MusicExampleActivity.class);
+                            VideoExampleActivity.class);
                     break;
                 }
                 case 7: {
+                    intent = new Intent(getActivity().getBaseContext(),
+                            MusicExampleActivity.class);
+                    break;
+                }
+                case 8: {
                     // Let's create a new Wizard for a given Movie. The movie can come from any sort
                     // of data source. To simplify this example we decode it from a JSON source
                     // which might be loaded from a server in a real world example.
@@ -160,13 +166,13 @@ public class MainFragment extends BrowseFragment {
                     // Finally, start the wizard Activity.
                     break;
                 }
-                case 8: {
+                case 9: {
                     intent = new Intent(getActivity().getBaseContext(),
                             SettingsExampleActivity.class);
                     startActivity(intent);
                     return;
                 }
-                case 9: {
+                case 10: {
                     intent = new Intent(getActivity().getBaseContext(),
                             DialogExampleActivity.class);
                     break;

--- a/app/src/main/java/android/support/v17/leanback/supportleanbackshowcase/app/details/DetailViewExampleActivity.java
+++ b/app/src/main/java/android/support/v17/leanback/supportleanbackshowcase/app/details/DetailViewExampleActivity.java
@@ -24,9 +24,27 @@ import android.support.v17.leanback.supportleanbackshowcase.R;
  */
 public class DetailViewExampleActivity extends Activity {
 
+    /***
+     * True if using trailer as a background.
+     */
+    protected boolean hasBackgroundVideo() {
+        return false;
+    }
+
+    /**
+     * Called when the activity is first created.
+     */
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_detail_example);
+
+        if (savedInstanceState == null) {
+            DetailViewExampleFragment fragment = new DetailViewExampleFragment();
+            fragment.setBackgroundVideo(hasBackgroundVideo());
+            getFragmentManager().beginTransaction()
+                    .replace(R.id.details_fragment, fragment)
+                    .commit();
+        }
     }
 }

--- a/app/src/main/java/android/support/v17/leanback/supportleanbackshowcase/app/details/DetailViewExampleActivity.java
+++ b/app/src/main/java/android/support/v17/leanback/supportleanbackshowcase/app/details/DetailViewExampleActivity.java
@@ -24,16 +24,6 @@ import android.support.v17.leanback.supportleanbackshowcase.R;
  */
 public class DetailViewExampleActivity extends Activity {
 
-    /***
-     * True if using trailer as a background.
-     */
-    protected boolean hasBackgroundVideo() {
-        return false;
-    }
-
-    /**
-     * Called when the activity is first created.
-     */
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -41,7 +31,6 @@ public class DetailViewExampleActivity extends Activity {
 
         if (savedInstanceState == null) {
             DetailViewExampleFragment fragment = new DetailViewExampleFragment();
-            fragment.setBackgroundVideo(hasBackgroundVideo());
             getFragmentManager().beginTransaction()
                     .replace(R.id.details_fragment, fragment)
                     .commit();

--- a/app/src/main/java/android/support/v17/leanback/supportleanbackshowcase/app/details/DetailViewExampleFragment.java
+++ b/app/src/main/java/android/support/v17/leanback/supportleanbackshowcase/app/details/DetailViewExampleFragment.java
@@ -161,10 +161,10 @@ public class DetailViewExampleFragment extends DetailsFragment implements OnItem
                 startEntranceTransition();
             }
         }, 500);
-        updateBackground(data);
+        initializeBackground(data);
     }
 
-    private void updateBackground(DetailedCard data) {
+    private void initializeBackground(DetailedCard data) {
         mDetailsBackground.enableParallax();
         mDetailsBackground.setCoverBitmap(BitmapFactory.decodeResource(getResources(),
                 R.drawable.background_canyon));

--- a/app/src/main/java/android/support/v17/leanback/supportleanbackshowcase/app/details/DetailViewExampleFragment.java
+++ b/app/src/main/java/android/support/v17/leanback/supportleanbackshowcase/app/details/DetailViewExampleFragment.java
@@ -13,12 +13,13 @@
  */
 
 package android.support.v17.leanback.supportleanbackshowcase.app.details;
-
-import android.graphics.Bitmap;
+;
 import android.graphics.BitmapFactory;
 import android.os.Bundle;
 import android.os.Handler;
 import android.support.v17.leanback.app.DetailsFragment;
+import android.support.v17.leanback.app.DetailsFragmentBackgroundController;
+import android.support.v17.leanback.media.MediaPlayerGlue;
 import android.support.v17.leanback.supportleanbackshowcase.models.DetailedCard;
 import android.support.v17.leanback.supportleanbackshowcase.R;
 import android.support.v17.leanback.supportleanbackshowcase.utils.CardListRow;
@@ -54,7 +55,13 @@ public class DetailViewExampleFragment extends DetailsFragment implements OnItem
     public static final String TRANSITION_NAME = "t_for_transition";
     public static final String EXTRA_CARD = "card";
 
+    // Play trailer on the background or not
+    private boolean BACKGROUND_PLAYER = true;
+
     private ArrayObjectAdapter mRowsAdapter;
+    private MediaPlayerGlue mMediaPlayerGlue;
+    private final DetailsFragmentBackgroundController mDetailsBackground =
+            new DetailsFragmentBackgroundController(this);
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -145,6 +152,24 @@ public class DetailViewExampleFragment extends DetailsFragment implements OnItem
                 startEntranceTransition();
             }
         }, 500);
+        updateBackground(data);
+    }
+
+    private void updateBackground(DetailedCard data) {
+        mDetailsBackground.enableParallax();
+        if (BACKGROUND_PLAYER) {
+            mDetailsBackground.setCoverBitmap(null);
+            mDetailsBackground.enableParallax();
+            mMediaPlayerGlue = new MediaPlayerGlue(getActivity());
+            mDetailsBackground.setupVideoPlayback(mMediaPlayerGlue);
+
+            mMediaPlayerGlue.setArtist(data.getDescription());
+            mMediaPlayerGlue.setTitle(data.getTitle());
+            mMediaPlayerGlue.setVideoUrl(data.getVideoUrl());
+        } else {
+            mDetailsBackground.setCoverBitmap(BitmapFactory.decodeResource(getResources(),
+                    R.drawable.background_canyon));
+        }
     }
 
     private void setupEventListeners() {
@@ -157,6 +182,7 @@ public class DetailViewExampleFragment extends DetailsFragment implements OnItem
                               RowPresenter.ViewHolder rowViewHolder, Row row) {
         if (!(item instanceof Action)) return;
         Action action = (Action) item;
+
         if (action.getId() == 3) {
             setSelectedPosition(1);
         } else {
@@ -174,5 +200,9 @@ public class DetailViewExampleFragment extends DetailsFragment implements OnItem
         } else {
             getView().setBackground(null);
         }
+    }
+
+    public void setBackgroundVideo(boolean backgroundVideo) {
+        BACKGROUND_PLAYER = backgroundVideo;
     }
 }

--- a/app/src/main/java/android/support/v17/leanback/supportleanbackshowcase/app/details/DetailViewExampleWithVideoBackgroundActivity.java
+++ b/app/src/main/java/android/support/v17/leanback/supportleanbackshowcase/app/details/DetailViewExampleWithVideoBackgroundActivity.java
@@ -12,6 +12,10 @@ import android.support.v17.leanback.supportleanbackshowcase.R;
 
 public class DetailViewExampleWithVideoBackgroundActivity extends Activity {
 
+    public static String WATCH_NOW = "watch_movie_now";
+
+    static final int BUY_MOVIE_REQUEST = 987;
+
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);

--- a/app/src/main/java/android/support/v17/leanback/supportleanbackshowcase/app/details/DetailViewExampleWithVideoBackgroundActivity.java
+++ b/app/src/main/java/android/support/v17/leanback/supportleanbackshowcase/app/details/DetailViewExampleWithVideoBackgroundActivity.java
@@ -1,18 +1,28 @@
 package android.support.v17.leanback.supportleanbackshowcase.app.details;
 
+import android.app.Activity;
 import android.os.Bundle;
 import android.support.v17.leanback.app.DetailsFragment;
+import android.support.v17.leanback.supportleanbackshowcase.R;
 
 /**
- * Contains a {@link DetailsFragment} in order to display more details for a given card.
+ * Contains a {@link DetailsFragment} with video background in order to display more details
+ * for a given card.
  */
 
-public class DetailViewExampleWithVideoBackgroundActivity extends DetailViewExampleActivity {
+public class DetailViewExampleWithVideoBackgroundActivity extends Activity {
 
-    /***
-     * True if using trailer as a background.
-     */
-    protected boolean hasBackgroundVideo() {
-        return true;
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_detail_example);
+
+        if (savedInstanceState == null) {
+            DetailViewExampleWithVideoBackgroundFragment fragment =
+                    new DetailViewExampleWithVideoBackgroundFragment();
+            getFragmentManager().beginTransaction()
+                    .replace(R.id.details_fragment, fragment)
+                    .commit();
+        }
     }
 }

--- a/app/src/main/java/android/support/v17/leanback/supportleanbackshowcase/app/details/DetailViewExampleWithVideoBackgroundActivity.java
+++ b/app/src/main/java/android/support/v17/leanback/supportleanbackshowcase/app/details/DetailViewExampleWithVideoBackgroundActivity.java
@@ -12,8 +12,6 @@ import android.support.v17.leanback.supportleanbackshowcase.R;
 
 public class DetailViewExampleWithVideoBackgroundActivity extends Activity {
 
-    public static String WATCH_NOW = "watch_movie_now";
-
     static final int BUY_MOVIE_REQUEST = 987;
 
     @Override

--- a/app/src/main/java/android/support/v17/leanback/supportleanbackshowcase/app/details/DetailViewExampleWithVideoBackgroundActivity.java
+++ b/app/src/main/java/android/support/v17/leanback/supportleanbackshowcase/app/details/DetailViewExampleWithVideoBackgroundActivity.java
@@ -1,0 +1,18 @@
+package android.support.v17.leanback.supportleanbackshowcase.app.details;
+
+import android.os.Bundle;
+import android.support.v17.leanback.app.DetailsFragment;
+
+/**
+ * Contains a {@link DetailsFragment} in order to display more details for a given card.
+ */
+
+public class DetailViewExampleWithVideoBackgroundActivity extends DetailViewExampleActivity {
+
+    /***
+     * True if using trailer as a background.
+     */
+    protected boolean hasBackgroundVideo() {
+        return true;
+    }
+}

--- a/app/src/main/java/android/support/v17/leanback/supportleanbackshowcase/app/details/DetailViewExampleWithVideoBackgroundFragment.java
+++ b/app/src/main/java/android/support/v17/leanback/supportleanbackshowcase/app/details/DetailViewExampleWithVideoBackgroundFragment.java
@@ -14,18 +14,17 @@
 
 package android.support.v17.leanback.supportleanbackshowcase.app.details;
 
-import android.graphics.BitmapFactory;
 import android.os.Bundle;
 import android.os.Handler;
 import android.support.v17.leanback.app.DetailsFragment;
 import android.support.v17.leanback.app.DetailsFragmentBackgroundController;
 import android.support.v17.leanback.media.MediaPlayerGlue;
-import android.support.v17.leanback.supportleanbackshowcase.models.DetailedCard;
 import android.support.v17.leanback.supportleanbackshowcase.R;
-import android.support.v17.leanback.supportleanbackshowcase.utils.CardListRow;
-import android.support.v17.leanback.supportleanbackshowcase.utils.Utils;
 import android.support.v17.leanback.supportleanbackshowcase.cards.presenters.CardPresenterSelector;
 import android.support.v17.leanback.supportleanbackshowcase.models.Card;
+import android.support.v17.leanback.supportleanbackshowcase.models.DetailedCard;
+import android.support.v17.leanback.supportleanbackshowcase.utils.CardListRow;
+import android.support.v17.leanback.supportleanbackshowcase.utils.Utils;
 import android.support.v17.leanback.widget.Action;
 import android.support.v17.leanback.widget.ArrayObjectAdapter;
 import android.support.v17.leanback.widget.ClassPresenterSelector;
@@ -49,16 +48,18 @@ import com.google.gson.Gson;
 /**
  * Displays a card with more details using a {@link DetailsFragment}.
  */
-public class DetailViewExampleFragment extends DetailsFragment implements OnItemViewClickedListener,
+public class DetailViewExampleWithVideoBackgroundFragment extends DetailsFragment implements OnItemViewClickedListener,
         OnItemViewSelectedListener {
 
     public static final String TRANSITION_NAME = "t_for_transition";
     public static final String EXTRA_CARD = "card";
 
-    private static final long ACTION_BUY = 1;
-    private static final long ACTION_WISHLIST = 2;
-    private static final long ACTION_RELATED = 3;
+    private static final long ACTION_PLAY = 1;
+    private static final long ACTION_BUY = 2;
+    private static final long ACTION_WISHLIST = 3;
+    private static final long ACTION_RELATED = 4;
 
+    private Action mActionPlay;
     private Action mActionBuy;
     private Action mActionWishList;
     private Action mActionRelated;
@@ -131,6 +132,7 @@ public class DetailViewExampleFragment extends DetailsFragment implements OnItem
         detailsOverview.setImageDrawable(getResources().getDrawable(imageResId, null));
         ArrayObjectAdapter actionAdapter = new ArrayObjectAdapter();
 
+        mActionPlay = new Action(ACTION_PLAY, getString(R.string.action_play));
         mActionBuy = new Action(ACTION_BUY, getString(R.string.action_buy) + data.getPrice());
         mActionWishList = new Action(ACTION_WISHLIST, getString(R.string.action_wishlist));
         mActionRelated = new Action(ACTION_RELATED, getString(R.string.action_related));
@@ -166,8 +168,13 @@ public class DetailViewExampleFragment extends DetailsFragment implements OnItem
 
     private void updateBackground(DetailedCard data) {
         mDetailsBackground.enableParallax();
-        mDetailsBackground.setCoverBitmap(BitmapFactory.decodeResource(getResources(),
-                R.drawable.background_canyon));
+
+        mMediaPlayerGlue = new MediaPlayerGlue(getActivity());
+        mDetailsBackground.setupVideoPlayback(mMediaPlayerGlue);
+
+        mMediaPlayerGlue.setTitle(data.getTitle().concat(" (Trailer)"));
+        mMediaPlayerGlue.setArtist(data.getDescription());
+        mMediaPlayerGlue.setVideoUrl(data.getTrailerUrl());
     }
 
     private void setupEventListeners() {
@@ -180,8 +187,20 @@ public class DetailViewExampleFragment extends DetailsFragment implements OnItem
                               RowPresenter.ViewHolder rowViewHolder, Row row) {
         if (!(item instanceof Action)) return;
         Action action = (Action) item;
+        long id = action.getId();
 
-        if (action.getId() == ACTION_RELATED) {
+        ArrayObjectAdapter actionAdapter = (ArrayObjectAdapter)
+                ((DetailsOverviewRow) getAdapter().get(0)).getActionsAdapter();
+
+        if (id == ACTION_PLAY) {
+            // TODO: play main video on background
+            Toast.makeText(getActivity(), getString(R.string.action_cicked), Toast.LENGTH_LONG)
+                    .show();
+        } else if (id == ACTION_BUY) {
+            actionAdapter.add(0, mActionPlay);
+            actionAdapter.remove(mActionBuy);
+            setTitle(getTitle() + "(Owned)");
+        } else if (action.getId() == ACTION_RELATED) {
             setSelectedPosition(1);
         } else {
             Toast.makeText(getActivity(), getString(R.string.action_cicked), Toast.LENGTH_LONG)

--- a/app/src/main/java/android/support/v17/leanback/supportleanbackshowcase/app/details/DetailViewExampleWithVideoBackgroundFragment.java
+++ b/app/src/main/java/android/support/v17/leanback/supportleanbackshowcase/app/details/DetailViewExampleWithVideoBackgroundFragment.java
@@ -14,6 +14,7 @@
 
 package android.support.v17.leanback.supportleanbackshowcase.app.details;
 
+import android.app.Fragment;
 import android.os.Bundle;
 import android.os.Handler;
 import android.support.v17.leanback.app.DetailsFragment;
@@ -54,16 +55,15 @@ public class DetailViewExampleWithVideoBackgroundFragment extends DetailsFragmen
     public static final String TRANSITION_NAME = "t_for_transition";
     public static final String EXTRA_CARD = "card";
 
-    private static final long ACTION_PLAY = 1;
-    private static final long ACTION_BUY = 2;
-    private static final long ACTION_WISHLIST = 3;
-    private static final long ACTION_RELATED = 4;
+    private static final long ACTION_BUY = 1;
+    private static final long ACTION_WISHLIST = 2;
+    private static final long ACTION_RELATED = 3;
 
-    private Action mActionPlay;
     private Action mActionBuy;
     private Action mActionWishList;
     private Action mActionRelated;
     private ArrayObjectAdapter mRowsAdapter;
+    private DetailedCard data;
     private MediaPlayerGlue mMediaPlayerGlue;
     private final DetailsFragmentBackgroundController mDetailsBackground =
             new DetailsFragmentBackgroundController(this);
@@ -80,7 +80,7 @@ public class DetailViewExampleWithVideoBackgroundFragment extends DetailsFragmen
         // anywhere in a real world app, e.g. a server.
         String json = Utils
                 .inputStreamToString(getResources().openRawResource(R.raw.detail_example));
-        DetailedCard data = new Gson().fromJson(json, DetailedCard.class);
+        data = new Gson().fromJson(json, DetailedCard.class);
 
         // Setup fragment
         setTitle(getString(R.string.detail_view_title));
@@ -132,7 +132,6 @@ public class DetailViewExampleWithVideoBackgroundFragment extends DetailsFragmen
         detailsOverview.setImageDrawable(getResources().getDrawable(imageResId, null));
         ArrayObjectAdapter actionAdapter = new ArrayObjectAdapter();
 
-        mActionPlay = new Action(ACTION_PLAY, getString(R.string.action_play));
         mActionBuy = new Action(ACTION_BUY, getString(R.string.action_buy) + data.getPrice());
         mActionWishList = new Action(ACTION_WISHLIST, getString(R.string.action_wishlist));
         mActionRelated = new Action(ACTION_RELATED, getString(R.string.action_related));
@@ -163,10 +162,10 @@ public class DetailViewExampleWithVideoBackgroundFragment extends DetailsFragmen
                 startEntranceTransition();
             }
         }, 500);
-        updateBackground(data);
+        initializeBackground();
     }
 
-    private void updateBackground(DetailedCard data) {
+    private void initializeBackground() {
         mDetailsBackground.enableParallax();
 
         mMediaPlayerGlue = new MediaPlayerGlue(getActivity());
@@ -175,6 +174,17 @@ public class DetailViewExampleWithVideoBackgroundFragment extends DetailsFragmen
         mMediaPlayerGlue.setTitle(data.getTitle().concat(" (Trailer)"));
         mMediaPlayerGlue.setArtist(data.getDescription());
         mMediaPlayerGlue.setVideoUrl(data.getTrailerUrl());
+    }
+
+    private void playMainVideoOnBackground() {
+        mMediaPlayerGlue.reset();
+
+        mMediaPlayerGlue.setTitle(data.getTitle());
+        mMediaPlayerGlue.setArtist(data.getDescription());
+        mMediaPlayerGlue.setVideoUrl(data.getVideoUrl());
+
+        Fragment mVideoFragment = mDetailsBackground.findOrCreateVideoFragment();
+        mVideoFragment.getView().requestFocus();
     }
 
     private void setupEventListeners() {
@@ -192,14 +202,11 @@ public class DetailViewExampleWithVideoBackgroundFragment extends DetailsFragmen
         ArrayObjectAdapter actionAdapter = (ArrayObjectAdapter)
                 ((DetailsOverviewRow) getAdapter().get(0)).getActionsAdapter();
 
-        if (id == ACTION_PLAY) {
-            // TODO: play main video on background
-            Toast.makeText(getActivity(), getString(R.string.action_cicked), Toast.LENGTH_LONG)
-                    .show();
-        } else if (id == ACTION_BUY) {
-            actionAdapter.add(0, mActionPlay);
+        if (id == ACTION_BUY) {
             actionAdapter.remove(mActionBuy);
             setTitle(getTitle() + "(Owned)");
+
+            playMainVideoOnBackground();
         } else if (action.getId() == ACTION_RELATED) {
             setSelectedPosition(1);
         } else {

--- a/app/src/main/java/android/support/v17/leanback/supportleanbackshowcase/app/details/DetailViewExampleWithVideoBackgroundFragment.java
+++ b/app/src/main/java/android/support/v17/leanback/supportleanbackshowcase/app/details/DetailViewExampleWithVideoBackgroundFragment.java
@@ -261,7 +261,7 @@ public class DetailViewExampleWithVideoBackgroundFragment extends DetailsFragmen
                 setTitle(getTitle() + " (Owned)");
 
                 boolean watchNow = returnIntent
-                        .getBooleanExtra(DetailViewExampleWithVideoBackgroundActivity.WATCH_NOW,
+                        .getBooleanExtra(WizardExampleActivity.WATCH_NOW,
                                 false);
 
                 if (watchNow) {

--- a/app/src/main/java/android/support/v17/leanback/supportleanbackshowcase/app/media/MusicConsumptionExampleFragment.java
+++ b/app/src/main/java/android/support/v17/leanback/supportleanbackshowcase/app/media/MusicConsumptionExampleFragment.java
@@ -39,8 +39,7 @@ import java.util.List;
  * This example shows how to play music files and build a simple track list.
  */
 public class MusicConsumptionExampleFragment extends PlaybackOverlayFragment implements
-        BaseOnItemViewClickedListener, BaseOnItemViewSelectedListener,
-        MediaPlayerGlue.OnMediaStateChangeListener {
+        BaseOnItemViewClickedListener, MediaPlayerGlue.OnMediaStateChangeListener {
 
     private static final String TAG = "MusicConsumptionExampleFragment";
     private static final int PLAYLIST_ACTION_ID = 0;
@@ -243,7 +242,6 @@ public class MusicConsumptionExampleFragment extends PlaybackOverlayFragment imp
         mRowsAdapter.addAll(2, mSongList);
         setAdapter(mRowsAdapter);
         setOnItemViewClickedListener(this);
-        setOnItemViewSelectedListener(this);
     }
 
     public MusicConsumptionExampleFragment() {
@@ -286,12 +284,6 @@ public class MusicConsumptionExampleFragment extends PlaybackOverlayFragment imp
 
         }
     }
-
-    @Override
-    public void onItemSelected(Presenter.ViewHolder itemViewHolder, Object item,
-                               RowPresenter.ViewHolder rowViewHolder, Object row) {
-    }
-
 
     public void onSongDetailsClicked(Song song) {
         int nextSongIndex = mSongList.indexOf(song);

--- a/app/src/main/java/android/support/v17/leanback/supportleanbackshowcase/app/wizard/WizardExample4thStepFragment.java
+++ b/app/src/main/java/android/support/v17/leanback/supportleanbackshowcase/app/wizard/WizardExample4thStepFragment.java
@@ -67,7 +67,7 @@ public class WizardExample4thStepFragment extends WizardExampleBaseStepFragment 
         if (ACTION_ID_WATCH == action.getId()) {
             Toast.makeText(getActivity(), getString(R.string.wizard_example_watch_now_clicked),
                     Toast.LENGTH_SHORT).show();
-            returnIntent.putExtra(DetailViewExampleWithVideoBackgroundActivity.WATCH_NOW, true);
+            returnIntent.putExtra(WizardExampleActivity.WATCH_NOW, true);
 
         }
 

--- a/app/src/main/java/android/support/v17/leanback/supportleanbackshowcase/app/wizard/WizardExample4thStepFragment.java
+++ b/app/src/main/java/android/support/v17/leanback/supportleanbackshowcase/app/wizard/WizardExample4thStepFragment.java
@@ -14,9 +14,12 @@
 
 package android.support.v17.leanback.supportleanbackshowcase.app.wizard;
 
+import android.app.Activity;
+import android.content.Intent;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.v17.leanback.supportleanbackshowcase.R;
+import android.support.v17.leanback.supportleanbackshowcase.app.details.DetailViewExampleWithVideoBackgroundActivity;
 import android.support.v17.leanback.widget.GuidanceStylist;
 import android.support.v17.leanback.widget.GuidedAction;
 import android.widget.Toast;
@@ -60,10 +63,15 @@ public class WizardExample4thStepFragment extends WizardExampleBaseStepFragment 
 
     @Override
     public void onGuidedActionClicked(GuidedAction action) {
+        Intent returnIntent = new Intent();
         if (ACTION_ID_WATCH == action.getId()) {
             Toast.makeText(getActivity(), getString(R.string.wizard_example_watch_now_clicked),
                     Toast.LENGTH_SHORT).show();
+            returnIntent.putExtra(DetailViewExampleWithVideoBackgroundActivity.WATCH_NOW, true);
+
         }
+
+        getActivity().setResult(Activity.RESULT_OK, returnIntent);
         getActivity().finish();
     }
 }

--- a/app/src/main/java/android/support/v17/leanback/supportleanbackshowcase/app/wizard/WizardExampleActivity.java
+++ b/app/src/main/java/android/support/v17/leanback/supportleanbackshowcase/app/wizard/WizardExampleActivity.java
@@ -25,7 +25,7 @@ import android.support.v17.leanback.supportleanbackshowcase.R;
  */
 public class WizardExampleActivity extends Activity {
 
-    public static String WATCH_NOW = "watch_movie_now";
+    public static final String WATCH_NOW = "watch_movie_now";
 
     @Override
     public void onCreate(Bundle savedInstanceState) {

--- a/app/src/main/java/android/support/v17/leanback/supportleanbackshowcase/app/wizard/WizardExampleActivity.java
+++ b/app/src/main/java/android/support/v17/leanback/supportleanbackshowcase/app/wizard/WizardExampleActivity.java
@@ -25,6 +25,8 @@ import android.support.v17.leanback.supportleanbackshowcase.R;
  */
 public class WizardExampleActivity extends Activity {
 
+    public static String WATCH_NOW = "watch_movie_now";
+
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);

--- a/app/src/main/java/android/support/v17/leanback/supportleanbackshowcase/models/DetailedCard.java
+++ b/app/src/main/java/android/support/v17/leanback/supportleanbackshowcase/models/DetailedCard.java
@@ -30,6 +30,7 @@ public class DetailedCard {
     @SerializedName("characters") private Card[] mCharacters = null;
     @SerializedName("recommended") private Card[] mRecommended = null;
     @SerializedName("year") private int mYear = 0;
+    @SerializedName("videoUrl") private String mVideoUrl = null;
 
 
     public String getPrice() {
@@ -54,6 +55,10 @@ public class DetailedCard {
 
     public String getTitle() {
         return mTitle;
+    }
+
+    public String getVideoUrl() {
+        return mVideoUrl;
     }
 
     public Card[] getCharacters() {

--- a/app/src/main/java/android/support/v17/leanback/supportleanbackshowcase/models/DetailedCard.java
+++ b/app/src/main/java/android/support/v17/leanback/supportleanbackshowcase/models/DetailedCard.java
@@ -30,6 +30,7 @@ public class DetailedCard {
     @SerializedName("characters") private Card[] mCharacters = null;
     @SerializedName("recommended") private Card[] mRecommended = null;
     @SerializedName("year") private int mYear = 0;
+    @SerializedName("trailerUrl") private String mTrailerUrl = null;
     @SerializedName("videoUrl") private String mVideoUrl = null;
 
 
@@ -55,6 +56,10 @@ public class DetailedCard {
 
     public String getTitle() {
         return mTitle;
+    }
+
+    public String getTrailerUrl() {
+        return mTrailerUrl;
     }
 
     public String getVideoUrl() {

--- a/app/src/main/res/layout/activity_detail_example.xml
+++ b/app/src/main/res/layout/activity_detail_example.xml
@@ -14,12 +14,7 @@
      See the License for the specific language governing permissions and
      limitations under the License.
 -->
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent">
-    <fragment
-        android:id="@+id/detailsFragment"
-        android:name="android.support.v17.leanback.supportleanbackshowcase.app.details.DetailViewExampleFragment"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"></fragment>
-</RelativeLayout>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/details_fragment"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent" />

--- a/app/src/main/res/raw/detail_example.json
+++ b/app/src/main/res/raw/detail_example.json
@@ -5,6 +5,7 @@
   "text": "It was nine o’clock one sunny California morning, and Geoffrey Strong stood under the live-oak trees in Las Flores Cañon, with a pot of black paint in one hand and a huge brush in the other.  He could have handled these implements to better purpose and with better grace had not his arms been firmly held by three laughing girls, who pulled not wisely, but too well.  He was further incommoded by the presence of a small urchin who lay on the dusty ground beneath his feet, fastening an upward clutch on the legs of his trousers.\n\nThere were three large canvas tents directly in front of them, yet no one of these seemed to be the object of dissension, but rather a redwood board, some three feet in length, which was nailed on a tree near by. twitch of her cousin’s sleeve.",
   "localImageResource": "movie_poster_01",
   "price": "$9.99",
+  "trailerUrl": "https://storage.googleapis.com/android-tv/Sample videos/Google+/Google+_ Sharing but like real life.mp4",
   "videoUrl": "https://storage.googleapis.com/android-tv/Sample videos/Google+/Google+_ Sharing but like real life.mp4",
   "characters": [
     {

--- a/app/src/main/res/raw/detail_example.json
+++ b/app/src/main/res/raw/detail_example.json
@@ -5,6 +5,7 @@
   "text": "It was nine o’clock one sunny California morning, and Geoffrey Strong stood under the live-oak trees in Las Flores Cañon, with a pot of black paint in one hand and a huge brush in the other.  He could have handled these implements to better purpose and with better grace had not his arms been firmly held by three laughing girls, who pulled not wisely, but too well.  He was further incommoded by the presence of a small urchin who lay on the dusty ground beneath his feet, fastening an upward clutch on the legs of his trousers.\n\nThere were three large canvas tents directly in front of them, yet no one of these seemed to be the object of dissension, but rather a redwood board, some three feet in length, which was nailed on a tree near by. twitch of her cousin’s sleeve.",
   "localImageResource": "movie_poster_01",
   "price": "$9.99",
+  "videoUrl": "https://storage.googleapis.com/android-tv/Sample videos/Google+/Google+_ Sharing but like real life.mp4",
   "characters": [
     {
       "type": "CHARACTER",

--- a/app/src/main/res/raw/detail_example.json
+++ b/app/src/main/res/raw/detail_example.json
@@ -6,7 +6,7 @@
   "localImageResource": "movie_poster_01",
   "price": "$9.99",
   "trailerUrl": "https://storage.googleapis.com/android-tv/Sample videos/Google+/Google+_ Sharing but like real life.mp4",
-  "videoUrl": "https://storage.googleapis.com/android-tv/Sample videos/Google+/Google+_ Sharing but like real life.mp4",
+  "videoUrl": "https://storage.googleapis.com/android-tv/Sample videos/April Fool's 2013/Explore Treasure Mode with Google Maps.mp4",
   "characters": [
     {
       "type": "CHARACTER",

--- a/app/src/main/res/raw/launcher_cards.json
+++ b/app/src/main/res/raw/launcher_cards.json
@@ -40,33 +40,40 @@
       {
         "id": 5,
         "type": "DEFAULT",
+        "title": "Detail Examples with Video Background",
+        "localImageResource": "thumbnail_example_detail",
+        "description": "Showcase of various card design and layouts"
+      },
+      {
+        "id": 6,
+        "type": "DEFAULT",
         "title": "Video consumption Examples",
         "localImageResource": "thumbnail_example_video_consumption",
         "description": "Showcase of various card design and layouts"
       },
       {
-        "id": 6,
+        "id": 7,
         "type": "DEFAULT",
         "title": "Music consumption Examples",
         "localImageResource": "thumbnail_example_music_consumption",
         "description": "Showcase of various card design and layouts"
       },
       {
-        "id": 7,
+        "id": 8,
         "type": "DEFAULT",
         "title": "Wizard Examples",
         "localImageResource": "thumbnail_example_wizard",
         "description": "Showcase of various card design and layouts"
       },
       {
-        "id": 8,
+        "id": 9,
         "type": "DEFAULT",
         "title": "Settings Examples",
         "localImageResource": "thumbnail_example_settings",
         "description": "Showcase of various card design and layouts"
       },
       {
-        "id": 9,
+        "id": 10,
         "type": "DEFAULT",
         "title": "Dialog Examples",
         "localImageResource": "thumbnail_example_dialog",

--- a/app/src/main/res/raw/wizard_example.json
+++ b/app/src/main/res/raw/wizard_example.json
@@ -1,5 +1,5 @@
 {
-  "title": "Androidify! The Movie",
+  "title": "A Summer in a Canyon",
   "breadcrump": "Android TV",
   "price_hd": "$4.99",
   "price_sd": "$2.99"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -25,6 +25,9 @@
     <string name="grid_example_title">Image Grid Example</string>
     <string name="video_grid_example_title">Video Grid Example</string>
     <string name="videos_url">https://storage.googleapis.com/android-tv/android_tv_videos_new.json</string>
+    <string name="action_play">Play </string>
+    <string name="action_play_not_ready">The video is still being downloaded. Please wait and try
+            later.</string>
     <string name="action_buy">Buy </string>
     <string name="action_wishlist">Add to wishlist</string>
     <string name="action_related">Related</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -29,6 +29,7 @@
     <string name="action_play_not_ready">The video is still being downloaded. Please wait and try
             later.</string>
     <string name="action_buy">Buy </string>
+    <string name="action_rent">Rent </string>
     <string name="action_wishlist">Add to wishlist</string>
     <string name="action_related">Related</string>
     <string name="header_related">Related Items</string>
@@ -57,7 +58,7 @@
     <string name="wizard_example_rent">Rent</string>
     <string name="wizard_example_rent_hd">Rent HD</string>
     <string name="wizard_example_rent_sd">Rent SD</string>
-    <string name="wizard_example_processing">Processinig...</string>
+    <string name="wizard_example_processing">Processing...</string>
     <string name="wizard_example_watch_now">Watch now</string>
     <string name="wizard_example_later">Later</string>
     <string name="wizard_example_watch_now_clicked">\'Watch now\' clicked.</string>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -66,7 +66,6 @@
 
     <style name="Theme.Example.LeanbackDetails" parent="Theme.Leanback.Details">
         <item name="android:colorPrimary">@color/detail_view_actionbar_background</item>
-        <item name="android:windowBackground">@drawable/background_canyon</item>
      </style>
 
     <style name="Theme.Example.LeanbackMusic" parent="Theme.Example.Leanback">


### PR DESCRIPTION
In Sample Music Player forward and rewind buttons do not work. It seems that the onItemSelected method in MusicConsumptionExampleFragment override the onItemSelected method in MusicMediaPlayerGlue.