### PR TITLE
Fix forward and rewind buttons in Music Consumption Examples

### DIFF
--- a/app/src/main/java/android/support/v17/leanback/supportleanbackshowcase/app/media/MusicConsumptionExampleFragment.java
+++ b/app/src/main/java/android/support/v17/leanback/supportleanbackshowcase/app/media/MusicConsumptionExampleFragment.java
@@ -39,8 +39,7 @@ import java.util.List;
  * This example shows how to play music files and build a simple track list.
  */
 public class MusicConsumptionExampleFragment extends PlaybackOverlayFragment implements
-        BaseOnItemViewClickedListener, BaseOnItemViewSelectedListener,
-        MediaPlayerGlue.OnMediaStateChangeListener {
+        BaseOnItemViewClickedListener, MediaPlayerGlue.OnMediaStateChangeListener {
 
     private static final String TAG = "MusicConsumptionExampleFragment";
     private static final int PLAYLIST_ACTION_ID = 0;
@@ -243,7 +242,6 @@ public class MusicConsumptionExampleFragment extends PlaybackOverlayFragment imp
         mRowsAdapter.addAll(2, mSongList);
         setAdapter(mRowsAdapter);
         setOnItemViewClickedListener(this);
-        setOnItemViewSelectedListener(this);
     }
 
     public MusicConsumptionExampleFragment() {
@@ -286,12 +284,6 @@ public class MusicConsumptionExampleFragment extends PlaybackOverlayFragment imp
 
         }
     }
-
-    @Override
-    public void onItemSelected(Presenter.ViewHolder itemViewHolder, Object item,
-                               RowPresenter.ViewHolder rowViewHolder, Object row) {
-    }
-
 
     public void onSongDetailsClicked(Song song) {
         int nextSongIndex = mSongList.indexOf(song);

--- a/app/src/main/java/android/support/v17/leanback/supportleanbackshowcase/app/media/MusicMediaPlayerGlue.java
+++ b/app/src/main/java/android/support/v17/leanback/supportleanbackshowcase/app/media/MusicMediaPlayerGlue.java
@@ -50,7 +50,6 @@ import android.support.v17.leanback.widget.RowPresenter;
 import android.util.Log;
 import android.view.KeyEvent;
 import android.view.View;
-import android.widget.TextView;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -64,7 +63,7 @@ import java.util.List;
  * <p/>
  */
 public abstract class MusicMediaPlayerGlue extends MediaPlayerGlue implements
-        OnItemViewSelectedListener, MusicPlaybackService.ServiceCallback {
+        MusicPlaybackService.ServiceCallback {
 
     public static final int FAST_FORWARD_REWIND_STEP = 10 * 1000; // in milliseconds
     public static final int FAST_FORWARD_REWIND_REPEAT_DELAY = 200; // in milliseconds
@@ -493,7 +492,6 @@ public abstract class MusicMediaPlayerGlue extends MediaPlayerGlue implements
         }
     }
 
-
     /**
      * This is a listener implementation for the {@link OnItemViewSelectedListener} of the {@link
      * PlaybackOverlayFragment}. This implementation is required in order to detect KEY_DOWN events
@@ -506,13 +504,13 @@ public abstract class MusicMediaPlayerGlue extends MediaPlayerGlue implements
      * @see OnItemViewSelectedListener#onItemSelected(Presenter.ViewHolder, Object,
      * RowPresenter.ViewHolder, Row)
      */
-    @Override public void onItemSelected(Presenter.ViewHolder itemViewHolder, Object item,
-                                         RowPresenter.ViewHolder rowViewHolder, Row row) {
+    @Override
+    public void onItemSelected(Presenter.ViewHolder itemViewHolder, Object item,
+            RowPresenter.ViewHolder rowViewHolder, Row row) {
         if (item instanceof Action) {
             mSelectedAction = (Action) item;
         } else {
             mSelectedAction = null;
         }
     }
-
 }


### PR DESCRIPTION
In Sample Music Player forward and rewind buttons do not work. It seems that the onItemSelected method in MusicConsumptionExampleFragment override the onItemSelected method in MusicMediaPlayerGlue.

Test: Manual