### PR TITLE
Fix the error when clicking Settings examples

### DIFF
--- a/app/src/main/java/android/support/v17/leanback/supportleanbackshowcase/app/settings/SettingsExampleFragment.java
+++ b/app/src/main/java/android/support/v17/leanback/supportleanbackshowcase/app/settings/SettingsExampleFragment.java
@@ -100,6 +100,7 @@ public class SettingsExampleFragment extends LeanbackSettingsFragment implements
 
         @Override
         public void onDetach() {
+            if (fragments.size()>0)
             fragments.pop();
             super.onDetach();
         }


### PR DESCRIPTION
A crash happens when popping from empty fragments stack in the SettingsExampleFragment.java